### PR TITLE
feat(advice): the meter read for you, three rules behind an `a` popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Advice: the meter read for you.** Press `a` for a popup with one sentence per thing that looks like a bad deal on the machine right now, the numbers behind it, and what you could do. Three rules, applied to figures already on screen and only to live agents: an **expensive source** (a tool or MCP server whose results run to 8k tokens or more per call and have added at least 40k tokens to the prompt, so every response since has paid to re-read them: *`docs-search` MCP server: 1 call added 40k tokens to the prompt, re-read at a cost of $12.03 since*), an **idle MCP server** (attached to a live agent, no calls in ten minutes or more; quiet whenever the process-to-server join is incomplete), and a **growing MCP server** (memory up at least 64 MB and half again over ten minutes or more, still climbing, never dipping, with no calls in the window: the shape of a leak before it becomes an orphan). Nothing is done for you: agent-top still never signals a process or edits a config, it points. `--once` prints the sentences under `ADVICE`; `--json` carries them as `advice` with rule, subject, pid and the numbers. The collector now samples each attached MCP server's memory every 30 seconds for the last hour to feed the leak rule; that memory is per run and never written anywhere.
+
 ## [0.14.0] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ What to look at first:
 - **COST** is what each session has spent so far, at list price.
 - **Red rows in the detail pane** are MCP servers whose agent has gone. They are the leak this tool exists to catch.
 
-Keys: `j`/`k` move, `Tab` switches the detail pane between the process tree and the tool trace, `s` sorts, `x` hides stopped sessions, `l` opens the slowest-tools panel, `f` the failed-tools panel, `?` shows the rest, `q` quits.
+Keys: `j`/`k` move, `Tab` switches the detail pane between the process tree and the tool trace, `s` sorts, `x` hides stopped sessions, `l` opens the slowest-tools panel, `f` the failed-tools panel, `a` the advice panel, `?` shows the rest, `q` quits.
 
 Other ways to run it:
 
@@ -190,6 +190,37 @@ main table stays uncluttered. Press `l` for the **slowest tools** (ranked by
 time, with calls, total, average and max) and `f` for **failed tool calls**
 (ranked by failures, with the fail rate). Each closes with the same key or
 `Esc`, and is accented amber or red so you know which one is open.
+
+### Advice
+
+Everything above is a meter. Press `a` and agent-top reads it for you: a
+violet popup with one sentence per thing that looks like a bad deal, the
+numbers that make it one, and what you could do about it. Three rules, each
+applied to figures already on screen and only to live agents:
+
+- **An expensive source.** A tool or MCP server whose results are large per
+  call (8k tokens or more, about a thousand-line file) and have added at
+  least 40k tokens to the prompt, so every response since has paid to re-read
+  them. *`docs-search` MCP server: 1 call added 40k tokens to the prompt,
+  re-read at a cost of $12.03 since.* Ask it for smaller results, read in
+  parts, or start a fresh session.
+- **An idle MCP server.** A server process attached to a live agent that has
+  answered no calls in ten minutes or more. Its tool definitions still go out
+  with every response. Remove it from the project's MCP config. This rule
+  stays quiet when the process-to-server join is incomplete, so a server that
+  was called under another name is never called idle; it inherits the
+  process-name heuristic the MCP column uses.
+- **A growing MCP server.** A server whose memory has climbed steadily (at
+  least 64 MB and half again its size, over ten minutes or more, still going,
+  never dipping) with no calls in that window. That is the shape of a leak
+  before it becomes an orphan. Watch it, and kill it if it outlives its agent.
+
+Nothing is done for you. agent-top never signals a process or edits a config;
+it points, and the sentence carries its evidence so you can disagree with it.
+`--once` prints the same sentences under `ADVICE`, and `--json` carries them
+as `advice`, each with its rule, subject, pid and the numbers behind it. The
+thresholds are constants in `agent_top_core::advice`, each with the reason it
+sits where it does.
 
 ### Exporting a trace
 

--- a/crates/agent-top-core/src/advice.rs
+++ b/crates/agent-top-core/src/advice.rs
@@ -1,0 +1,395 @@
+//! Advice: the meter read for you.
+//!
+//! Everything else in agent-top reports a number. This module applies a few
+//! rules to numbers already on the snapshot and says, in one sentence each,
+//! what looks like a bad deal and what you could do about it. It changes
+//! nothing: agent-top does not kill a process or edit a config, it points.
+//!
+//! Every rule fires only with its evidence in the sentence, because the same
+//! figure is bad for one tool and fine for another: a search server that
+//! cost $12 for three calls is a poor bargain, a test runner may not be. The
+//! thresholds are the constants below, each with the reason it is where it is.
+//!
+//! Rules apply to live agents only. A stopped session's re-reads are over,
+//! and its servers are gone, so there is nothing left to act on.
+
+use crate::model::{Advice, AdviceRule, AgentState, ContextOrigin, McpMatch, Snapshot};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+/// A tool result this large is a whole file or a whole page, not an answer:
+/// about the size of a 1,000 line source file. Below it, results are the
+/// normal cost of doing work and no rule fires.
+pub const BIG_RESULT_TOKENS: u64 = 8_000;
+/// A source must have added at least this much to the prompt before its
+/// results are worth a sentence, whatever their size per call.
+pub const MIN_SOURCE_TOKENS: u64 = 40_000;
+/// An attached server that has answered nothing for this long is not warming
+/// up, it is unused. Ten minutes covers a long first turn.
+pub const IDLE_SERVER_SECS: u64 = 10 * 60;
+/// Memory a server must gain over the window before it is called growth:
+/// enough to matter, and more than a page cache warming up.
+pub const GROWTH_BYTES: u64 = 64 << 20;
+/// ... and that gain must be at least half its starting size, so a server
+/// that was large from the start is not flagged for a small drift.
+pub const GROWTH_RATIO: f64 = 1.5;
+/// A trend shorter than this is a burst, not a leak.
+pub const GROWTH_WINDOW_SECS: u64 = 10 * 60;
+
+/// How one MCP process's memory has moved over the collector's window, for
+/// the leak rule. Built by the collector from its per-tick samples.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RssTrend {
+    /// When the oldest sample in the window was taken.
+    pub since: SystemTime,
+    pub from_bytes: u64,
+    pub to_bytes: u64,
+    /// No sample fell more than a few percent below the one before it: the
+    /// memory climbed rather than churned.
+    pub steady: bool,
+    /// Bytes gained over roughly the last ten minutes: a trend that has
+    /// flattened is a server that loaded something, not one that leaks.
+    pub recent_growth: u64,
+}
+
+/// Every piece of advice the snapshot supports, most expensive first.
+pub fn advise(snap: &Snapshot, trends: &HashMap<u32, RssTrend>) -> Vec<Advice> {
+    let mut out = Vec::new();
+    for a in snap.agents.iter().filter(|a| a.state != AgentState::Stopped) {
+        let priced = a.price_source.is_some();
+        for c in &a.context {
+            if c.origin == ContextOrigin::Other || c.calls == 0 {
+                continue;
+            }
+            let per_call = c.tokens / c.calls;
+            if per_call < BIG_RESULT_TOKENS || c.tokens < MIN_SOURCE_TOKENS {
+                continue;
+            }
+            let cost = priced.then_some(c.cost_usd);
+            let paid = match cost {
+                Some(usd) => format!("re-read at a cost of ${usd:.2} since"),
+                None => "re-read on every response since (unpriced model)".to_string(),
+            };
+            let (subject, headline, action) = match c.origin {
+                ContextOrigin::Mcp => (
+                    c.name.clone(),
+                    format!("{} MCP server: {} added {} tokens to the prompt, {}", c.name, calls(c.calls), tokens(c.tokens), paid),
+                    "ask it for smaller results, or drop it from this project's MCP config".to_string(),
+                ),
+                _ => (
+                    c.name.clone(),
+                    format!(
+                        "{}: {} added {} tokens to the prompt ({} each), {}",
+                        c.name,
+                        calls(c.calls),
+                        tokens(c.tokens),
+                        tokens(per_call),
+                        paid
+                    ),
+                    "read in smaller parts, or start a fresh session so the results stop being re-sent".to_string(),
+                ),
+            };
+            out.push(Advice {
+                agent_id: a.id.clone(),
+                agent_name: a.name.clone(),
+                rule: AdviceRule::ExpensiveSource,
+                subject,
+                pid: None,
+                headline,
+                action,
+                cost_usd: cost.unwrap_or(0.0),
+                tokens: c.tokens,
+                calls: c.calls,
+                rss_bytes: 0,
+            });
+        }
+
+        // The idle rule trusts the join: a server the transcript calls but no
+        // process could be matched to (`TranscriptOnly`) means some process
+        // row is that server under another name, so no process-only row of
+        // this agent can be called unused with any confidence.
+        let join_complete = !a.mcp_servers.iter().any(|m| m.matched_by == McpMatch::TranscriptOnly);
+        for m in &a.mcp_servers {
+            let Some(pid) = m.pid else { continue };
+            if join_complete && m.calls == 0 && a.turns > 0 && m.age_secs.unwrap_or(0) >= IDLE_SERVER_SECS {
+                out.push(Advice {
+                    agent_id: a.id.clone(),
+                    agent_name: a.name.clone(),
+                    rule: AdviceRule::IdleMcpServer,
+                    subject: m.name.clone(),
+                    pid: Some(pid),
+                    headline: format!(
+                        "{} (pid {pid}) has answered no calls in {} and holds {}",
+                        m.name,
+                        age(m.age_secs.unwrap_or(0)),
+                        bytes(m.rss_bytes)
+                    ),
+                    action: "remove it from this project's MCP config; its tool definitions are sent with every response".to_string(),
+                    cost_usd: 0.0,
+                    tokens: 0,
+                    calls: 0,
+                    rss_bytes: m.rss_bytes,
+                });
+            }
+            if let Some(t) = trends.get(&pid)
+                && is_leak_shaped(t, snap.taken_at)
+                && m.last_call.is_none_or(|c| c < t.since)
+            {
+                let over = snap.taken_at.duration_since(t.since).map(|d| d.as_secs()).unwrap_or(0);
+                out.push(Advice {
+                    agent_id: a.id.clone(),
+                    agent_name: a.name.clone(),
+                    rule: AdviceRule::GrowingMcpServer,
+                    subject: m.name.clone(),
+                    pid: Some(pid),
+                    headline: format!(
+                        "{} (pid {pid}) grew from {} to {} over {} with no calls",
+                        m.name,
+                        bytes(t.from_bytes),
+                        bytes(t.to_bytes),
+                        age(over)
+                    ),
+                    action: "a server that grows while unused is likely leaking; watch it, and kill it if it outlives its agent"
+                        .to_string(),
+                    cost_usd: 0.0,
+                    tokens: 0,
+                    calls: m.calls,
+                    rss_bytes: t.to_bytes,
+                });
+            }
+        }
+    }
+    // Money first, then the leaks, then the merely idle; ties by size.
+    out.sort_by(|x, y| {
+        rank(x.rule)
+            .cmp(&rank(y.rule))
+            .then(y.cost_usd.partial_cmp(&x.cost_usd).unwrap_or(std::cmp::Ordering::Equal))
+            .then(y.tokens.cmp(&x.tokens))
+            .then(y.rss_bytes.cmp(&x.rss_bytes))
+    });
+    out
+}
+
+fn rank(r: AdviceRule) -> u8 {
+    match r {
+        AdviceRule::ExpensiveSource => 0,
+        AdviceRule::GrowingMcpServer => 1,
+        AdviceRule::IdleMcpServer => 2,
+    }
+}
+
+/// The leak rule's shape test: a long enough, steady, still-continuing climb
+/// of at least `GROWTH_BYTES` and `GROWTH_RATIO`.
+fn is_leak_shaped(t: &RssTrend, now: SystemTime) -> bool {
+    let window = now.duration_since(t.since).map(|d| d.as_secs()).unwrap_or(0);
+    let grown = t.to_bytes.saturating_sub(t.from_bytes);
+    window >= GROWTH_WINDOW_SECS
+        && t.steady
+        && t.recent_growth > 0
+        && grown >= GROWTH_BYTES
+        && (t.to_bytes as f64) >= (t.from_bytes as f64) * GROWTH_RATIO
+}
+
+fn calls(n: u64) -> String {
+    if n == 1 { "1 call".into() } else { format!("{n} calls") }
+}
+
+fn tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1e6)
+    } else if n >= 10_000 {
+        format!("{}k", n / 1000)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1e3)
+    } else {
+        n.to_string()
+    }
+}
+
+fn bytes(n: u64) -> String {
+    const MB: f64 = 1024.0 * 1024.0;
+    if n as f64 >= 1024.0 * MB { format!("{:.1} GB", n as f64 / (1024.0 * MB)) } else { format!("{:.0} MB", n as f64 / MB) }
+}
+
+fn age(secs: u64) -> String {
+    if secs >= 3600 { format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60) } else { format!("{}m", secs / 60) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::*;
+    use std::time::Duration;
+
+    fn agent(id: &str) -> Agent {
+        Agent {
+            id: format!("pid:{id}"),
+            name: format!("claude:{id}"),
+            harness: Harness::Claude,
+            state: AgentState::Running,
+            activity: Activity::Working,
+            pid: Some(1),
+            session_id: None,
+            session_path: None,
+            cwd: None,
+            model: Some("claude-fable-5-1".into()),
+            harness_version: None,
+            usage: TokenUsage::default(),
+            cost_usd: 0.0,
+            cost_breakdown: Default::default(),
+            price_source: Some(PriceSource::Builtin),
+            unpriced_tokens: 0,
+            turns: 5,
+            subagent_turns: 0,
+            tool_calls: 0,
+            web_searches: 0,
+            spans: Vec::new(),
+            age_secs: 3600,
+            idle_secs: None,
+            cpu_percent: 0.0,
+            rss_bytes: 0,
+            process_count: 1,
+            mcp_count: 0,
+            mcp_servers: Vec::new(),
+            context: Vec::new(),
+            tree: None,
+            attribution: Attribution::HarnessRegistry,
+            shares_process: false,
+            parse_warning: None,
+            rate_limit: None,
+        }
+    }
+
+    fn source(name: &str, origin: ContextOrigin, calls: u64, tokens: u64, cost_usd: f64) -> ContextSource {
+        ContextSource { name: name.into(), origin, calls, tokens, cost_usd }
+    }
+
+    fn server(name: &str, pid: u32, calls: u64, age_secs: u64, rss: u64, matched_by: McpMatch) -> McpServer {
+        McpServer {
+            name: name.into(),
+            pid: Some(pid),
+            cmdline: None,
+            cpu_percent: 0.0,
+            rss_bytes: rss,
+            age_secs: Some(age_secs),
+            calls,
+            errors: 0,
+            last_call: None,
+            matched_by,
+        }
+    }
+
+    fn snapshot(agents: Vec<Agent>) -> Snapshot {
+        Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            taken_at: SystemTime::UNIX_EPOCH + Duration::from_secs(10_000),
+            host: HostStats::default(),
+            agents,
+            orphans: Vec::new(),
+            orphan_origins: Vec::new(),
+            advice: Vec::new(),
+            totals: Totals::default(),
+        }
+    }
+
+    #[test]
+    fn an_oversized_result_is_flagged_with_its_cost_and_a_small_one_is_not() {
+        let mut a = agent("proj");
+        a.context = vec![
+            // One MCP call that dumped 40k tokens: the headline example.
+            source("docs-search", ContextOrigin::Mcp, 1, 40_000, 12.03),
+            // Three whole-file reads.
+            source("Read", ContextOrigin::Tool, 3, 120_000, 40.10),
+            // Many small results, more tokens in total, but each is a normal answer.
+            source("Bash", ContextOrigin::Tool, 200, 400_000, 90.0),
+            // A big result that has not been re-read enough to matter yet.
+            source("Grep", ContextOrigin::Tool, 1, 9_000, 0.02),
+            source("prompts & replies", ContextOrigin::Other, 0, 900_000, 200.0),
+        ];
+        let out = advise(&snapshot(vec![a]), &HashMap::new());
+        let subjects: Vec<&str> = out.iter().map(|x| x.subject.as_str()).collect();
+        assert_eq!(subjects, ["Read", "docs-search"], "most expensive first: {out:#?}");
+        assert!(out.iter().all(|x| x.rule == AdviceRule::ExpensiveSource));
+        let read = &out[0];
+        assert_eq!(read.headline, "Read: 3 calls added 120k tokens to the prompt (40k each), re-read at a cost of $40.10 since");
+        assert!(read.action.contains("smaller parts"));
+        let mcp = &out[1];
+        assert_eq!(mcp.headline, "docs-search MCP server: 1 call added 40k tokens to the prompt, re-read at a cost of $12.03 since");
+        assert!(mcp.action.contains("MCP config"));
+        assert_eq!((mcp.calls, mcp.tokens, mcp.cost_usd), (1, 40_000, 12.03));
+    }
+
+    #[test]
+    fn an_unpriced_model_still_gets_the_size_advice_without_a_dollar_figure() {
+        let mut a = agent("proj");
+        a.price_source = None;
+        a.context = vec![source("Read", ContextOrigin::Tool, 1, 50_000, 0.0)];
+        let out = advise(&snapshot(vec![a]), &HashMap::new());
+        assert_eq!(out.len(), 1);
+        assert!(out[0].headline.ends_with("(unpriced model)"), "{}", out[0].headline);
+        assert!(!out[0].headline.contains('$'));
+    }
+
+    #[test]
+    fn an_attached_server_with_no_calls_is_idle_unless_the_join_is_incomplete() {
+        let mut a = agent("proj");
+        a.mcp_servers = vec![
+            server("server-filesystem", 11, 0, 42 * 60, 180 << 20, McpMatch::ProcessOnly),
+            server("git", 12, 9, 42 * 60, 50 << 20, McpMatch::Name),
+            // Just started: no verdict yet.
+            server("fresh", 13, 0, 30, 20 << 20, McpMatch::ProcessOnly),
+        ];
+        let out = advise(&snapshot(vec![a.clone()]), &HashMap::new());
+        assert_eq!(out.len(), 1, "{out:#?}");
+        assert_eq!(out[0].rule, AdviceRule::IdleMcpServer);
+        assert_eq!(out[0].pid, Some(11));
+        assert_eq!(out[0].headline, "server-filesystem (pid 11) has answered no calls in 42m and holds 180 MB");
+
+        // A called server with no process means one of the process-only rows
+        // is really that server; nothing can be called idle.
+        a.mcp_servers.push(McpServer { pid: None, ..server("scratchfs", 0, 4, 0, 0, McpMatch::TranscriptOnly) });
+        assert!(advise(&snapshot(vec![a.clone()]), &HashMap::new()).is_empty());
+
+        // A stopped session has no servers to remove.
+        a.mcp_servers.pop();
+        a.state = AgentState::Stopped;
+        assert!(advise(&snapshot(vec![a]), &HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn a_server_that_keeps_growing_while_unused_is_a_leak_candidate() {
+        let snap_at = SystemTime::UNIX_EPOCH + Duration::from_secs(10_000);
+        let mut a = agent("proj");
+        let mut chrome = server("chrome-devtools", 77, 3, 3 * 3600, 410 << 20, McpMatch::Name);
+        chrome.last_call = Some(snap_at - Duration::from_secs(2 * 3600));
+        a.mcp_servers = vec![chrome];
+        let trend = RssTrend {
+            since: snap_at - Duration::from_secs(34 * 60),
+            from_bytes: 120 << 20,
+            to_bytes: 410 << 20,
+            steady: true,
+            recent_growth: 8 << 20,
+        };
+        let snap = snapshot(vec![a.clone()]);
+        let out = advise(&snap, &HashMap::from([(77, trend)]));
+        assert_eq!(out.len(), 1, "{out:#?}");
+        assert_eq!(out[0].rule, AdviceRule::GrowingMcpServer);
+        assert_eq!(out[0].headline, "chrome-devtools (pid 77) grew from 120 MB to 410 MB over 34m with no calls");
+
+        // Called during the window: it may be caching what it was asked for.
+        let mut called = a.clone();
+        called.mcp_servers[0].last_call = Some(snap_at - Duration::from_secs(60));
+        assert!(advise(&snapshot(vec![called]), &HashMap::from([(77, trend)])).is_empty());
+        // Flattened out: it loaded something and stopped.
+        let flat = RssTrend { recent_growth: 0, ..trend };
+        assert!(advise(&snap, &HashMap::from([(77, flat)])).is_empty());
+        // Churning up and down is not a leak.
+        let churn = RssTrend { steady: false, ..trend };
+        assert!(advise(&snap, &HashMap::from([(77, churn)])).is_empty());
+        // Too short a window, or too little growth.
+        let short = RssTrend { since: snap_at - Duration::from_secs(5 * 60), ..trend };
+        assert!(advise(&snap, &HashMap::from([(77, short)])).is_empty());
+        let small = RssTrend { from_bytes: 380 << 20, ..trend };
+        assert!(advise(&snap, &HashMap::from([(77, small)])).is_empty());
+    }
+}

--- a/crates/agent-top-core/src/collector.rs
+++ b/crates/agent-top-core/src/collector.rs
@@ -5,10 +5,11 @@
 //! and opens a tracker for one. The collector walks the process forest, asks
 //! the adapter for each root, and builds the rows.
 
+use crate::advice::RssTrend;
 use crate::harness::{self, AttributeContext, HarnessAdapter, McpUsage, RegistryHints, SessionSummary, SessionTracker, SpanRetention};
 use crate::model::*;
 use crate::process::{ProcessScanner, RawProc, build_forest};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -52,6 +53,57 @@ struct McpMemory {
     first_seen: SystemTime,
     parent: Option<OrphanParent>,
     orphaned_at: Option<SystemTime>,
+    /// (when, RSS of the server's subtree), one sample per `RSS_SAMPLE_EVERY`,
+    /// the last `RSS_WINDOW` of them, for the leak rule.
+    rss: VecDeque<(SystemTime, u64)>,
+}
+
+/// How often a server's memory is sampled: a leak shows over minutes, and a
+/// sample a second would be sixty times the memory for the same trend.
+const RSS_SAMPLE_EVERY: Duration = Duration::from_secs(30);
+/// How far back the samples go.
+const RSS_WINDOW: Duration = Duration::from_secs(60 * 60);
+/// "Recent" for the still-growing test: the trend over the last ten minutes.
+const RSS_RECENT: Duration = Duration::from_secs(10 * 60);
+/// A sample this far below the one before it is a churn, not a climb.
+const RSS_DIP: f64 = 0.05;
+
+impl McpMemory {
+    fn new(start_time: u64, now: SystemTime) -> Self {
+        McpMemory { start_time, first_seen: now, parent: None, orphaned_at: None, rss: VecDeque::new() }
+    }
+
+    fn sample(&mut self, now: SystemTime, rss: u64) {
+        if let Some((t, _)) = self.rss.back()
+            && now.duration_since(*t).map(|d| d < RSS_SAMPLE_EVERY).unwrap_or(true)
+        {
+            return;
+        }
+        self.rss.push_back((now, rss));
+        while let Some((t, _)) = self.rss.front()
+            && now.duration_since(*t).map(|d| d > RSS_WINDOW).unwrap_or(false)
+        {
+            self.rss.pop_front();
+        }
+    }
+
+    /// The window's shape, or `None` with fewer than two samples.
+    fn trend(&self, now: SystemTime) -> Option<RssTrend> {
+        let (&(since, from_bytes), &(_, to_bytes)) = (self.rss.front()?, self.rss.back()?);
+        if self.rss.len() < 2 {
+            return None;
+        }
+        let steady = self.rss.iter().zip(self.rss.iter().skip(1)).all(|((_, a), (_, b))| (*b as f64) >= (*a as f64) * (1.0 - RSS_DIP));
+        // The newest sample at least `RSS_RECENT` old, or the oldest if none is.
+        let anchor = self
+            .rss
+            .iter()
+            .rev()
+            .find(|(t, _)| now.duration_since(*t).map(|d| d >= RSS_RECENT).unwrap_or(false))
+            .map(|(_, b)| *b)
+            .unwrap_or(from_bytes);
+        Some(RssTrend { since, from_bytes, to_bytes, steady, recent_growth: to_bytes.saturating_sub(anchor) })
+    }
 }
 
 impl Collector {
@@ -300,7 +352,7 @@ impl Collector {
         let keep: HashSet<&PathBuf> = agents.iter().filter_map(|a| a.session_path.as_ref()).collect();
         self.trackers.retain(|p, _| keep.contains(p));
 
-        let orphan_origins = self.remember_mcp(&agents, &orphans, &by_pid, now);
+        let (orphan_origins, trends) = self.remember_mcp(&agents, &orphans, &by_pid, now);
 
         let mut snap = Snapshot {
             schema_version: SNAPSHOT_SCHEMA_VERSION,
@@ -309,9 +361,11 @@ impl Collector {
             agents,
             orphans,
             orphan_origins,
+            advice: Vec::new(),
             totals: Totals::default(),
         };
         snap.compute_totals();
+        snap.advice = crate::advice::advise(&snap, &trends);
         snap
     }
 
@@ -327,16 +381,18 @@ impl Collector {
         orphans: &[ProcNode],
         by_pid: &HashMap<u32, &RawProc>,
         now: SystemTime,
-    ) -> Vec<OrphanOrigin> {
+    ) -> (Vec<OrphanOrigin>, HashMap<u32, RssTrend>) {
         let start_of = |pid: u32| by_pid.get(&pid).map(|p| p.start_time).unwrap_or(0);
         for a in agents {
             let Some(tree) = &a.tree else { continue };
             let parent = OrphanParent { pid: tree.pid, agent_id: a.id.clone(), name: a.name.clone() };
-            let under: Vec<u32> = tree.mcp_roots().iter().map(|n| n.pid).collect();
-            for pid in under {
+            // A server's memory is its whole subtree, as its row shows it.
+            let under: Vec<(u32, u64)> = tree.mcp_roots().iter().map(|n| (n.pid, n.totals().1)).collect();
+            for (pid, rss) in under {
                 let m = touch(&mut self.mcp_memory, pid, start_of(pid), now);
                 m.parent = Some(parent.clone());
                 m.orphaned_at = None;
+                m.sample(now, rss);
             }
         }
         let mut origins = Vec::with_capacity(orphans.len());
@@ -350,16 +406,17 @@ impl Collector {
         // A process that has exited is forgotten, so the map does not grow
         // with every server ever started.
         self.mcp_memory.retain(|pid, _| by_pid.contains_key(pid));
-        origins
+        let trends = self.mcp_memory.iter().filter_map(|(pid, m)| m.trend(now).map(|t| (*pid, t))).collect();
+        (origins, trends)
     }
 }
 
 /// The memory entry for a process, fresh if the pid is new or has been
 /// reused by a process with a different start time.
 fn touch(memory: &mut HashMap<u32, McpMemory>, pid: u32, start_time: u64, now: SystemTime) -> &mut McpMemory {
-    let entry = memory.entry(pid).or_insert(McpMemory { start_time, first_seen: now, parent: None, orphaned_at: None });
+    let entry = memory.entry(pid).or_insert_with(|| McpMemory::new(start_time, now));
     if entry.start_time != start_time {
-        *entry = McpMemory { start_time, first_seen: now, parent: None, orphaned_at: None };
+        *entry = McpMemory::new(start_time, now);
     }
     entry
 }
@@ -653,7 +710,7 @@ mod tests {
         let by_pid: HashMap<u32, &RawProc> = procs.iter().map(|p| (p.pid, p)).collect();
 
         // Tick 0: the server is under its agent; 99 is an orphan from the start.
-        let origins = c.remember_mcp(std::slice::from_ref(&agent), &[node(99, ProcKind::Mcp, "uvx mcp-server-git")], &by_pid, t0);
+        let (origins, _) = c.remember_mcp(std::slice::from_ref(&agent), &[node(99, ProcKind::Mcp, "uvx mcp-server-git")], &by_pid, t0);
         assert_eq!(origins.len(), 1);
         assert_eq!(origins[0].pid, 99);
         assert!(origins[0].parent.is_none());
@@ -664,7 +721,7 @@ mod tests {
         let procs = [raw(11, 6), raw(99, 7)];
         let by_pid: HashMap<u32, &RawProc> = procs.iter().map(|p| (p.pid, p)).collect();
         let orphans = [node(11, ProcKind::Mcp, "npx server-filesystem"), node(99, ProcKind::Mcp, "uvx mcp-server-git")];
-        let origins = c.remember_mcp(&[], &orphans, &by_pid, t1);
+        let (origins, _) = c.remember_mcp(&[], &orphans, &by_pid, t1);
         let fs = origins.iter().find(|o| o.pid == 11).unwrap();
         assert_eq!(fs.parent.as_ref().map(|p| (p.pid, p.name.as_str())), Some((10, "claude:proj")));
         assert_eq!(fs.orphaned_at, Some(t1));
@@ -675,9 +732,119 @@ mod tests {
         // Tick 2: pid 11 is reused by a different process. The memory starts over.
         let procs = [raw(11, 900)];
         let by_pid: HashMap<u32, &RawProc> = procs.iter().map(|p| (p.pid, p)).collect();
-        let origins = c.remember_mcp(&[], &orphans[..1], &by_pid, t1 + Duration::from_secs(10));
+        let (origins, _) = c.remember_mcp(&[], &orphans[..1], &by_pid, t1 + Duration::from_secs(10));
         assert!(origins[0].parent.is_none());
         assert!(!c.mcp_memory.contains_key(&99), "an exited process is forgotten");
+    }
+
+    /// The leak rule's input, driven tick by tick: samples are taken every
+    /// half minute at most, the window's shape says whether the memory
+    /// climbed, and a server that keeps climbing while unused reaches the
+    /// snapshot as advice.
+    #[test]
+    fn a_servers_memory_is_sampled_over_the_run_and_a_steady_climb_becomes_advice() {
+        let mut c = Collector::new(CollectorOptions::default());
+        let t0 = UNIX_EPOCH + Duration::from_secs(1_000);
+        let mut agent = Agent {
+            id: "pid:10".into(),
+            name: "claude:proj".into(),
+            harness: Harness::Claude,
+            state: AgentState::Running,
+            activity: Activity::Working,
+            pid: Some(10),
+            session_id: None,
+            session_path: None,
+            cwd: None,
+            model: None,
+            harness_version: None,
+            usage: TokenUsage::default(),
+            cost_usd: 0.0,
+            cost_breakdown: Default::default(),
+            price_source: None,
+            unpriced_tokens: 0,
+            turns: 3,
+            subagent_turns: 0,
+            tool_calls: 0,
+            web_searches: 0,
+            spans: Vec::new(),
+            age_secs: 0,
+            idle_secs: None,
+            cpu_percent: 0.0,
+            rss_bytes: 0,
+            process_count: 2,
+            mcp_count: 1,
+            mcp_servers: Vec::new(),
+            context: Vec::new(),
+            tree: None,
+            attribution: Attribution::HarnessRegistry,
+            shares_process: false,
+            parse_warning: None,
+            rate_limit: None,
+        };
+        let procs = [raw(10, 5), raw(11, 6)];
+        let by_pid: HashMap<u32, &RawProc> = procs.iter().map(|p| (p.pid, p)).collect();
+        let tick = |c: &mut Collector, agent: &mut Agent, at: SystemTime, rss: u64| {
+            let mut root = node(10, ProcKind::Agent, "claude");
+            let mut server = node(11, ProcKind::Mcp, "npx chrome-devtools-mcp");
+            server.rss_bytes = rss;
+            root.children = vec![server];
+            agent.tree = Some(root);
+            c.remember_mcp(std::slice::from_ref(agent), &[], &by_pid, at).1
+        };
+
+        // Two ticks a second apart: one sample, so no trend yet.
+        assert!(!tick(&mut c, &mut agent, t0, 100 << 20).contains_key(&11));
+        assert!(!tick(&mut c, &mut agent, t0 + Duration::from_secs(1), 100 << 20).contains_key(&11));
+        assert_eq!(c.mcp_memory[&11].rss.len(), 1, "a second sample waits {RSS_SAMPLE_EVERY:?}");
+
+        // Growing 8 MB a minute for 40 minutes: a steady climb, still going.
+        let mut trends = HashMap::new();
+        for minute in 1..=40u64 {
+            trends = tick(&mut c, &mut agent, t0 + Duration::from_secs(minute * 60), (100 + 8 * minute) << 20);
+        }
+        let t = trends[&11];
+        assert_eq!(t.since, t0);
+        assert_eq!((t.from_bytes, t.to_bytes), (100 << 20, 420 << 20));
+        assert!(t.steady);
+        assert_eq!(t.recent_growth, 80 << 20, "the last ten minutes");
+
+        // The whole way through to the snapshot's advice, with the row the
+        // collector would build for the server.
+        agent.mcp_servers = vec![McpServer {
+            name: "chrome-devtools".into(),
+            pid: Some(11),
+            cmdline: None,
+            cpu_percent: 0.0,
+            rss_bytes: 420 << 20,
+            age_secs: Some(40 * 60),
+            calls: 2,
+            errors: 0,
+            last_call: Some(t0 - Duration::from_secs(60)),
+            matched_by: McpMatch::Name,
+        }];
+        let snap = Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            taken_at: t0 + Duration::from_secs(40 * 60),
+            host: HostStats::default(),
+            agents: vec![agent.clone()],
+            orphans: Vec::new(),
+            orphan_origins: Vec::new(),
+            advice: Vec::new(),
+            totals: Totals::default(),
+        };
+        let advice = crate::advice::advise(&snap, &trends);
+        assert_eq!(advice.len(), 1, "{advice:#?}");
+        assert_eq!(advice[0].rule, AdviceRule::GrowingMcpServer);
+        assert_eq!(advice[0].headline, "chrome-devtools (pid 11) grew from 100 MB to 420 MB over 40m with no calls");
+
+        // A drop of more than a few percent breaks the climb.
+        let trends = tick(&mut c, &mut agent, t0 + Duration::from_secs(41 * 60), 300 << 20);
+        assert!(!trends[&11].steady);
+
+        // The window slides: after an hour the oldest samples are gone.
+        let trends = tick(&mut c, &mut agent, t0 + Duration::from_secs(100 * 60), 300 << 20);
+        assert!(trends[&11].since > t0);
+        assert!(c.mcp_memory[&11].rss.len() <= 2 * 60 + 1);
     }
 
     #[test]

--- a/crates/agent-top-core/src/lib.rs
+++ b/crates/agent-top-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! coding agents are on this machine right now, what are they doing, and what
 //! have they spent?" The TUI crate renders the answer; `--json` prints it.
 
+pub mod advice;
 pub mod collector;
 pub mod harness;
 pub mod jsonl;

--- a/crates/agent-top-core/src/model.rs
+++ b/crates/agent-top-core/src/model.rs
@@ -593,6 +593,58 @@ pub struct OrphanParent {
     pub name: String,
 }
 
+/// Which rule a piece of advice came from. See `advice`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AdviceRule {
+    /// A tool or MCP server whose results are large per call and have been
+    /// re-read on every response since: the biggest line in the bill hiding
+    /// behind a few calls.
+    ExpensiveSource,
+    /// An MCP server attached to a live agent that has answered no calls in
+    /// a long while.
+    IdleMcpServer,
+    /// An MCP server whose memory has climbed steadily with no calls to
+    /// explain it.
+    GrowingMcpServer,
+}
+
+impl AdviceRule {
+    pub fn label(self) -> &'static str {
+        match self {
+            AdviceRule::ExpensiveSource => "expensive source",
+            AdviceRule::IdleMcpServer => "idle mcp server",
+            AdviceRule::GrowingMcpServer => "growing mcp server",
+        }
+    }
+}
+
+/// One sentence of advice about one agent, with the numbers that back it and
+/// the thing you could do. Nothing is done for you: agent-top only points.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Advice {
+    pub agent_id: String,
+    pub agent_name: String,
+    pub rule: AdviceRule,
+    /// The tool, or the MCP server, the advice is about.
+    pub subject: String,
+    /// The server's process, when the advice is about one.
+    pub pid: Option<u32>,
+    /// What was seen, with its numbers.
+    pub headline: String,
+    /// What you might do about it.
+    pub action: String,
+    /// The evidence as numbers, for scripts: zero where a rule has none.
+    #[serde(default)]
+    pub cost_usd: f64,
+    #[serde(default)]
+    pub tokens: u64,
+    #[serde(default)]
+    pub calls: u64,
+    #[serde(default)]
+    pub rss_bytes: u64,
+}
+
 /// Everything the UI needs for one frame.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Snapshot {
@@ -605,6 +657,10 @@ pub struct Snapshot {
     /// One entry per orphan, saying where it came from when that is known.
     #[serde(default)]
     pub orphan_origins: Vec<OrphanOrigin>,
+    /// What looks like a bad deal on this machine right now, and what could
+    /// be done about it. See `advice`.
+    #[serde(default)]
+    pub advice: Vec<Advice>,
     pub totals: Totals,
 }
 

--- a/crates/agent-top/src/app.rs
+++ b/crates/agent-top/src/app.rs
@@ -86,6 +86,8 @@ pub enum Overlay {
     SlowTools,
     /// Tool calls ranked by how often they failed.
     FailedTools,
+    /// What looks like a bad deal right now, and what to do about it.
+    Advice,
 }
 
 pub struct App {
@@ -250,6 +252,7 @@ impl App {
             KeyCode::Char('h') | KeyCode::Char('?') | KeyCode::F(1) => self.toggle(Overlay::Help),
             KeyCode::Char('l') => self.toggle(Overlay::SlowTools),
             KeyCode::Char('f') => self.toggle(Overlay::FailedTools),
+            KeyCode::Char('a') => self.toggle(Overlay::Advice),
             KeyCode::Esc => self.overlay = Overlay::None,
             _ => {}
         }
@@ -344,6 +347,7 @@ mod tests {
             agents: vec![agent],
             orphans: Vec::new(),
             orphan_origins: Vec::new(),
+            advice: Vec::new(),
             totals: Totals::default(),
         };
         s.compute_totals();

--- a/crates/agent-top/src/format.rs
+++ b/crates/agent-top/src/format.rs
@@ -211,6 +211,13 @@ pub fn plain_table(snap: &Snapshot) -> String {
             }
         }
     }
+    if !snap.advice.is_empty() {
+        out.push_str("\nADVICE (from the numbers above; nothing is done for you)\n");
+        for x in &snap.advice {
+            out.push_str(&format!("  {:<24} {}\n", truncate(&x.agent_name, 24), x.headline));
+            out.push_str(&format!("  {:<24}   → {}\n", "", x.action));
+        }
+    }
     // A stopped session's rate-limit snapshot is from when it last ran, so it
     // is not a current warning; only live and idle agents carry a limit that
     // still applies. The detail pane still shows the figure for any session.
@@ -294,4 +301,48 @@ pub fn price_table(t: &Table) -> String {
     }
     out.push_str("\nA model with no entry here is counted but reported as unpriced, never guessed at.\n");
     out
+}
+
+#[cfg(test)]
+mod advice_tests {
+    use super::plain_table;
+    use agent_top_core::{Advice, AdviceRule, HostStats, SNAPSHOT_SCHEMA_VERSION, Snapshot, Totals};
+    use std::time::SystemTime;
+
+    /// `--once` prints the same sentences the popup shows, headline then
+    /// action, so a script or a screenshot carries the advice too.
+    #[test]
+    fn plain_table_prints_an_advice_section_when_there_is_any() {
+        let mut snap = Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            taken_at: SystemTime::UNIX_EPOCH,
+            host: HostStats::default(),
+            agents: Vec::new(),
+            orphans: Vec::new(),
+            orphan_origins: Vec::new(),
+            advice: Vec::new(),
+            totals: Totals::default(),
+        };
+        assert!(!plain_table(&snap).contains("ADVICE"));
+        snap.advice.push(Advice {
+            agent_id: "pid:7".into(),
+            agent_name: "claude:proj".into(),
+            rule: AdviceRule::GrowingMcpServer,
+            subject: "chrome-devtools".into(),
+            pid: Some(77),
+            headline: "chrome-devtools (pid 77) grew from 120 MB to 410 MB over 34m with no calls".into(),
+            action: "a server that grows while unused is likely leaking; watch it, and kill it if it outlives its agent".into(),
+            cost_usd: 0.0,
+            tokens: 0,
+            calls: 3,
+            rss_bytes: 410 << 20,
+        });
+        let out = plain_table(&snap);
+        assert!(out.contains("\nADVICE (from the numbers above; nothing is done for you)\n"), "{out}");
+        assert!(
+            out.contains("claude:proj              chrome-devtools (pid 77) grew from 120 MB to 410 MB over 34m with no calls\n"),
+            "{out}"
+        );
+        assert!(out.contains("→ a server that grows while unused is likely leaking"), "{out}");
+    }
 }

--- a/crates/agent-top/src/ui.rs
+++ b/crates/agent-top/src/ui.rs
@@ -208,8 +208,84 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         Overlay::Help => draw_help(f, area),
         Overlay::SlowTools => draw_tool_panel(f, area, &app.snapshot, ToolPanel::Slow),
         Overlay::FailedTools => draw_tool_panel(f, area, &app.snapshot, ToolPanel::Failed),
+        Overlay::Advice => draw_advice_panel(f, area, &app.snapshot),
         Overlay::None => {}
     }
+}
+
+/// The advice panel's colour: violet, so it is neither the amber of time
+/// nor the red of failure. Advice is a suggestion, not an alarm.
+const ADVICE: Color = Color::Rgb(190, 140, 255);
+
+/// A centred popup listing every piece of advice on the snapshot: one
+/// headline with its numbers, and under it, dimmed, what could be done. The
+/// rules and their thresholds live in `agent_top_core::advice`.
+fn draw_advice_panel(f: &mut Frame, area: Rect, snap: &agent_top_core::Snapshot) {
+    let advice = &snap.advice;
+    let w = 84.min(area.width.saturating_sub(2));
+    let inner = w.saturating_sub(4) as usize;
+    let mut lines: Vec<Line> = Vec::new();
+    if advice.is_empty() {
+        lines.push(Line::styled("  nothing to suggest: no oversized results, idle servers or growing servers", Style::default().fg(DIM)));
+    } else {
+        let mut last_agent = "";
+        for x in advice {
+            if x.agent_name != last_agent {
+                if !lines.is_empty() {
+                    lines.push(Line::raw(""));
+                }
+                lines.push(Line::from(vec![
+                    Span::styled(format!("  {}", x.agent_name), Style::default().fg(ACCENT).bold()),
+                    Span::styled(format!("  {}", x.agent_id), Style::default().fg(DIM)),
+                ]));
+                last_agent = &x.agent_name;
+            }
+            let (mark, colour) = match x.rule {
+                agent_top_core::AdviceRule::ExpensiveSource => ("$", Color::Rgb(220, 160, 40)),
+                agent_top_core::AdviceRule::GrowingMcpServer => ("↑", Color::Red),
+                agent_top_core::AdviceRule::IdleMcpServer => ("·", DIM),
+            };
+            for (i, part) in wrap(&x.headline, inner.saturating_sub(4)).into_iter().enumerate() {
+                let lead = if i == 0 { format!("  {mark} ") } else { "    ".to_string() };
+                lines.push(Line::from(vec![Span::styled(lead, Style::default().fg(colour).bold()), Span::raw(part)]));
+            }
+            for part in wrap(&x.action, inner.saturating_sub(6)) {
+                lines.push(Line::styled(format!("      {part}"), Style::default().fg(DIM)));
+            }
+        }
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::styled("  read from the numbers on screen; nothing is done for you · a or Esc to close", Style::default().fg(DIM)));
+    let h = (lines.len() as u16 + 2).clamp(6, area.height.saturating_sub(2));
+    let popup = Rect { x: area.x + (area.width - w) / 2, y: area.y + (area.height - h) / 2, width: w, height: h };
+    f.render_widget(Clear, popup);
+    let title = if advice.is_empty() { " advice ".to_string() } else { format!(" advice ({}) ", advice.len()) };
+    let block = Block::default()
+        .borders(ratatui::widgets::Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(ADVICE))
+        .title(Span::styled(title, Style::default().fg(ADVICE).bold()));
+    f.render_widget(Paragraph::new(Text::from(lines)).block(block), popup);
+}
+
+/// Greedy word wrap to `width` columns; a single overlong word stands alone.
+fn wrap(s: &str, width: usize) -> Vec<String> {
+    let width = width.max(16);
+    let mut out = Vec::new();
+    let mut line = String::new();
+    for word in s.split_whitespace() {
+        if !line.is_empty() && line.chars().count() + 1 + word.chars().count() > width {
+            out.push(std::mem::take(&mut line));
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() || out.is_empty() {
+        out.push(line);
+    }
+    out
 }
 
 /// One tool's stats, summed over every agent on screen.
@@ -1062,6 +1138,8 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
     left.push(sep());
     left.extend(key("l", "slow tools", amber));
     left.extend(key("f", "fails", Color::Red));
+    let n = app.snapshot.advice.len();
+    left.extend(key("a", if n > 0 { format!("advice ({n})") } else { "advice".to_string() }.as_str(), ADVICE));
     left.push(sep());
     left.extend(key("?", "help", ACCENT));
 
@@ -1094,6 +1172,11 @@ fn draw_help(f: &mut Frame, area: Rect) {
             Span::styled("slowest tools", Style::default().fg(Color::Rgb(220, 160, 40))),
             Span::raw("       f       "),
             Span::styled("failed tool calls", Style::default().fg(Color::Red)),
+        ]),
+        Line::from(vec![
+            Span::raw("  a            "),
+            Span::styled("advice", Style::default().fg(ADVICE)),
+            Span::raw(": oversized results, idle and growing MCP servers"),
         ]),
         Line::raw(""),
         Line::from(vec![Span::styled(format!("agent-top {}", crate::VERSION), Style::default().fg(ACCENT).bold())]),
@@ -1216,6 +1299,7 @@ mod tests {
             agents,
             orphans: Vec::new(),
             orphan_origins: Vec::new(),
+            advice: Vec::new(),
             totals: Totals::default(),
         };
         s.compute_totals();
@@ -1505,6 +1589,65 @@ mod tests {
         assert!(out.contains("failed tool calls"), "{out}");
         assert!(out.lines().any(|l| l.contains("Bash")), "the failing tool is listed: {out}");
         assert!(!out.lines().any(|l| l.contains("Read")), "a clean tool is not in the failures panel: {out}");
+    }
+
+    /// The advice popup lists every piece of advice under its agent, with a
+    /// mark per rule, and closes on the same key; an empty snapshot says so.
+    #[test]
+    fn advice_popup_lists_headlines_with_their_actions() {
+        use agent_top_core::{Advice, AdviceRule};
+        let mut snap = snapshot(vec![agent("worker", Vec::new())]);
+        let mut app = App::new(snap.clone());
+        app.on_key(ratatui::crossterm::event::KeyCode::Char('a'));
+        assert_eq!(app.overlay, Overlay::Advice);
+        let out = render(&mut app, 100, 40);
+        assert!(out.contains("nothing to suggest"), "{out}");
+        app.on_key(ratatui::crossterm::event::KeyCode::Char('a'));
+        assert_eq!(app.overlay, Overlay::None);
+
+        snap.advice = vec![
+            Advice {
+                agent_id: "pid:6".into(),
+                agent_name: "worker".into(),
+                rule: AdviceRule::ExpensiveSource,
+                subject: "docs-search".into(),
+                pid: None,
+                headline: "docs-search MCP server: 1 call added 40k tokens to the prompt, re-read at a cost of $12.03 since".into(),
+                action: "ask it for smaller results, or drop it from this project's MCP config".into(),
+                cost_usd: 12.03,
+                tokens: 40_000,
+                calls: 1,
+                rss_bytes: 0,
+            },
+            Advice {
+                agent_id: "pid:6".into(),
+                agent_name: "worker".into(),
+                rule: AdviceRule::IdleMcpServer,
+                subject: "server-filesystem".into(),
+                pid: Some(11),
+                headline: "server-filesystem (pid 11) has answered no calls in 42m and holds 180 MB".into(),
+                action: "remove it from this project's MCP config; its tool definitions are sent with every response".into(),
+                cost_usd: 0.0,
+                tokens: 0,
+                calls: 0,
+                rss_bytes: 180 << 20,
+            },
+        ];
+        let mut app = App::new(snap);
+        app.overlay = Overlay::Advice;
+        let out = render(&mut app, 100, 40);
+        println!("{out}");
+        assert!(out.contains("advice (2)"), "{out}");
+        assert!(out.contains("$ docs-search MCP server: 1 call added 40k tokens"), "{out}");
+        assert!(out.contains("· server-filesystem (pid 11) has answered no calls in 42m"), "{out}");
+        assert!(out.contains("ask it for smaller results"), "{out}");
+        // The footer badge counts it too (wide enough that the bar is not clipped).
+        let wide = render(&mut app, 140, 40);
+        let footer = wide.lines().last().unwrap();
+        assert!(footer.contains("advice (2)"), "footer counts it: {footer}");
+        // Narrow terminal: the headline wraps rather than clipping.
+        let out = render(&mut app, 60, 40);
+        assert!(out.contains("re-read at a cost of $12.03 since"), "{out}");
     }
 
     #[test]


### PR DESCRIPTION
Everything agent-top shows is a number. Now it reads them: press `a` for
one sentence per thing that looks like a bad deal, the numbers that make
it one, and what could be done. Nothing is done for you; agent-top still
never signals a process or edits a config, it points.

Three rules in a harness-neutral `advice` module, applied to live agents
only: an expensive source (a tool or MCP server whose results run to 8k
tokens or more per call and have added 40k+ tokens to the prompt, so every
response since has paid to re-read them), an idle MCP server (attached, no
calls in ten minutes or more; quiet whenever the process-to-server join is
incomplete so a server called under another name is never called idle),
and a growing MCP server (up 64 MB and half again over ten minutes or
more, still climbing, never dipping, with no calls in the window: the
shape of a leak before it becomes an orphan). The collector samples each
attached server's subtree RSS every 30 s for the last hour to feed it;
per run, never written anywhere.

Surfaced as a violet popup on `a` (headline, then the action dimmed),
an ADVICE section in --once, and `advice` on the --json snapshot with
rule, subject, pid and the numbers. Thresholds are named constants with
the reason each sits where it does.
