### PR TITLE
docs: build the site with uv instead of pip

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,14 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: docs/requirements.txt
-
-      - name: Install the site builder
-        run: pip install -r docs/requirements.txt
+          enable-cache: true
+          cache-dependency-glob: docs/requirements.txt
 
       - name: Build the site (strict)
-        run: mkdocs build --strict
+        run: uv run --python 3.12 --with-requirements docs/requirements.txt mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ target/
 .claude/settings.local.json
 *.log
 site/
-.venv/
 __pycache__/

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -152,18 +152,18 @@ Cloudflare Pages project settings, once, in the dashboard:
 | Setting | Value |
 |---|---|
 | Production branch | `main` |
-| Build command | `pip install -r docs/requirements.txt && mkdocs build --strict` |
+| Build command | `curl -LsSf https://astral.sh/uv/install.sh \| sh && $HOME/.local/bin/uv run --python 3.12 --with-requirements docs/requirements.txt mkdocs build --strict` |
 | Build output directory | `site` |
-| Environment variable | `PYTHON_VERSION=3.12` |
+| Environment variable | none needed; uv fetches Python 3.12 itself |
 
+The build command installs uv into the build container and runs mkdocs from a throwaway environment pinned by `docs/requirements.txt`; nothing is installed with pip.
 `docs/_headers` is copied into the output and sets the response headers.
 Preview deployments are built for pull requests automatically.
 
 To work on the site locally:
 
 ```sh
-uv venv .venv && uv pip install -r docs/requirements.txt
-.venv/bin/mkdocs serve     # http://127.0.0.1:8000, rebuilds on save
+uv run --with-requirements docs/requirements.txt mkdocs serve   # http://127.0.0.1:8000, rebuilds on save
 ```
 
 Screenshots are made from the synthetic snapshot, never a live machine:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 # Build dependencies for the documentation site (mkdocs.yml at the repo root).
+# Used through uv: `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
 mkdocs-material==9.7.7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,10 @@
 # Documentation site for agent-top, built with Material for MkDocs.
 #
-#   uv venv .venv && uv pip install -r docs/requirements.txt
-#   .venv/bin/mkdocs serve          # http://127.0.0.1:8000
-#   .venv/bin/mkdocs build --strict # what CI and Cloudflare Pages run
+#   uv run --with-requirements docs/requirements.txt mkdocs serve          # http://127.0.0.1:8000
+#   uv run --with-requirements docs/requirements.txt mkdocs build --strict # what CI and Cloudflare Pages run
+#
+# uv makes a throwaway environment from docs/requirements.txt; there is no
+# virtualenv to create or activate.
 #
 # The site loads nothing from third parties: no web fonts, no analytics, no
 # CDN. Everything it needs is in the built `site/` directory.


### PR DESCRIPTION
Every Python step for the docs site now goes through uv: `uv run --with-requirements docs/requirements.txt mkdocs ...` locally, `astral-sh/setup-uv` in the docs workflow, and the uv installer inside the Cloudflare Pages build command (documented in `docs/releasing.md`). No virtualenv to create, no pip anywhere.