### PR TITLE
docs: sidebar links, plainer footer, mono site title, Rust on the home page

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -207,4 +207,4 @@ agent-top is one static binary, and most of what makes it work was written by ot
 
 </div>
 
-agent-top is MIT licensed and written by Kannan Kalidasan. The crate dependency list, with every version, is in [`Cargo.lock`](https://github.com/kannandreams/agent-top/blob/main/Cargo.lock).
+agent-top is MIT licensed. The crate dependency list, with every version, is in [`Cargo.lock`](https://github.com/kannandreams/agent-top/blob/main/Cargo.lock).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ agent-top
 
 Coding agents have become long-running processes, and you tend to keep several at once, each in its own window with its own cost and its own leaks. No single harness shows them together. agent-top does, the way `htop` does it for processes and `btop` for the whole machine.
 
-It reads the transcripts the harnesses already write and the process table the OS already keeps. There is nothing to configure and nothing to enable in your agents. It never writes to, signals or kills an agent, and your data never leaves the machine.
+It is written in Rust and ships as one static binary for macOS and Linux: no runtime, no daemon, nothing to configure and nothing to enable in your agents. It reads the transcripts the harnesses already write and the process table the OS already keeps. It never writes to, signals or kills an agent, and your data never leaves the machine.
 
 ## What to look at first
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -418,3 +418,52 @@
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--at-line);
 }
+
+/* Site title in the header: the mono face, like the tool's own name. */
+.md-header__title {
+  font-family: var(--at-mono);
+  font-weight: 700;
+}
+
+/* The two outside links at the foot of the sidebar, each with its mark. */
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://github.com"],
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://crates.io"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  color: var(--at-muted);
+}
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://github.com"]::before,
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://crates.io"]::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background-color: currentColor;
+  -webkit-mask: var(--at-icon) no-repeat center / contain;
+  mask: var(--at-icon) no-repeat center / contain;
+}
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://github.com"] {
+  margin-top: 1.4em;
+  --at-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/></svg>");
+}
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://crates.io"] {
+  --at-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linejoin='round'><path d='M12 2.5 3.5 7v10l8.5 4.5 8.5-4.5V7z'/><path d='M3.5 7 12 11.5 20.5 7M12 11.5v10'/></svg>");
+}
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://github.com"]:hover,
+.md-nav--primary > .md-nav__list > .md-nav__item > .md-nav__link[href^="https://crates.io"]:hover {
+  color: var(--at-blue);
+}
+
+/* Footer line. */
+.at-footer {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+}
+.at-footer img {
+  border-radius: 4px;
+}
+.md-footer-meta {
+  border-top: 1px solid var(--at-line);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ site_url: https://agent-top.pages.dev
 repo_url: https://github.com/kannandreams/agent-top
 repo_name: kannandreams/agent-top
 edit_uri: edit/main/docs/
-copyright: MIT licensed. Made by Kannan Kalidasan.
+copyright: <span class="at-footer">MIT licensed. <img src="/assets/favicon.svg" alt="" width="18" height="18"> agent-top is built with ❤️ and 🦀 Rust.</span>
 
 docs_dir: docs
 site_dir: site
@@ -70,14 +70,7 @@ hooks:
   - docs/hooks/changelog_links.py
 
 extra:
-  generator: true
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/kannandreams/agent-top
-      name: agent-top on GitHub
-    - icon: fontawesome/solid/cube
-      link: https://crates.io/crates/agent-top
-      name: agent-top on crates.io
+  generator: false
 
 markdown_extensions:
   - admonition
@@ -130,3 +123,5 @@ nav:
       - Credits: credits.md
   - Blog:
       - blog/index.md
+  - GitHub: https://github.com/kannandreams/agent-top
+  - crates.io: https://crates.io/crates/agent-top


### PR DESCRIPTION
Site title in JetBrains Mono. GitHub and crates.io links at the foot of the sidebar with icons. Footer reduced to the licence, the logo and a built-with-love-and-Rust line; no author or generator credit. Home page states agent-top is written in Rust and ships as one static binary. Credits no longer name the author.