### PR TITLE
docs: reorder the report sections; justify body text

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -32,18 +32,6 @@ Each column:
 - **CACHE** is the share of the prompt served from cache. High is efficient. A low number on a long-running model is money left on the table.
 - **UNPRICED** is how many tokens the `+` stands for. The footer says what to do about it.
 
-## By day
-
-`--by day` is a spend timeline: one row per calendar day of last activity, most expensive first.
-
-![agent-top report for the last fourteen days, by day](screenshots/report-by-day.png)
-
-## By model
-
-`--by model` answers which model the money went to. A model with no price shows `$0.00+` and its tokens under UNPRICED rather than a believable small number.
-
-![agent-top report since the beginning, by model](screenshots/report-by-model.png)
-
 ## By project
 
 `--by project` groups by working directory, shown as its last two path components, and turns the report into a rough cost-per-repository view: which of the repos you work in is actually costing the most.
@@ -55,6 +43,18 @@ agent-top report --since all --by project
 The image below uses invented project names and numbers, not a real machine's, because a real one would publish repository names. Everywhere else on this page the report is real, since a cost total alone gives nothing away; a project breakdown does not, so here it is illustrative only.
 
 ![agent-top report by project, with example projects and made-up numbers](screenshots/report-by-project.png)
+
+## By day
+
+`--by day` is a spend timeline: one row per calendar day of last activity, most expensive first.
+
+![agent-top report for the last fourteen days, by day](screenshots/report-by-day.png)
+
+## By model
+
+`--by model` answers which model the money went to. A model with no price shows `$0.00+` and its tokens under UNPRICED rather than a believable small number.
+
+![agent-top report since the beginning, by model](screenshots/report-by-model.png)
 
 ## Reconciling with your harness
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -300,10 +300,19 @@
   color: var(--at-ink);
   max-width: 38em;
   margin: 0 0 1.4em;
-  text-wrap: pretty;
 }
+/* Justified body text: on a monospace face, inter-word justification snaps
+ * to the character grid, so the right edge lines up flush against code
+ * blocks and screenshots without the uneven word-gaps justify usually
+ * brings to a proportional face. The last line of a paragraph is left as
+ * the browser leaves it, ragged, which is the readable default. */
 .md-typeset p {
-  text-wrap: pretty;
+  text-align: justify;
+  text-justify: inter-word;
+}
+.at-lead {
+  text-align: justify;
+  text-justify: inter-word;
 }
 
 /* Credits: cards in the spirit of charm.land. A quiet border at rest, a blue


### PR DESCRIPTION
agent-top report --by project now follows --by harness rather than trailing after day and model. Body paragraphs and the home page lead are justified (inter-word), which reads cleanly on the monospace face instead of ragged-right.