### PR TITLE
docs: switch site_url and every doc link to agenttop.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Coding agents have become long-running processes, and you tend to keep several at once, each in its own window with its own cost and its own leaks. No single harness shows them together. `agent-top` does, the way `htop` does it for processes and `btop` for the whole machine. At a glance you can see which agent is burning tokens, which is waiting on you, and which MCP server is still alive after the agent that started it died.
 
-**Docs: [agent-top.pages.dev](https://agent-top.pages.dev)**, including [the blog](https://agent-top.pages.dev/blog/) and a guide to every panel.
+**Docs: [agenttop.dev](https://agenttop.dev)**, including [the blog](https://agenttop.dev/blog/) and a guide to every panel.
 
 ![agent-top](https://raw.githubusercontent.com/kannandreams/agent-top/main/docs/demo.gif)
 
@@ -447,7 +447,7 @@ others or the machine underneath: the subagents, the MCP servers, the memory
 they hold, or what the day has cost across all of them. `agent-top` is the one
 screen for that, read-only, built from the transcripts the harnesses already
 write and the process table the OS already keeps. The longer version is
-[on the docs site](https://agent-top.pages.dev/why-this-exists/).
+[on the docs site](https://agenttop.dev/why-this-exists/).
 
 One failure it watches for deserves a mention on its own: a leaked MCP process
 tree, helper processes a harness spawns and never reaps, piling up until they
@@ -455,7 +455,7 @@ leak gigabytes. It is a real, still-open class of bug, and it is not one
 vendor's. `agent-top` watches for the symptom rather than the vendor, so a
 server left alive after its agent died shows as a red row with the agent it
 came from. How that happens, with the reports, is in
-[The MCP server that outlives its agent](https://agent-top.pages.dev/blog/the-server-that-outlives-its-agent/).
+[The MCP server that outlives its agent](https://agenttop.dev/blog/the-server-that-outlives-its-agent/).
 
 ## Where the numbers come from
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,31 +6,31 @@ agent-top is a single Rust binary, MIT licensed, source at https://github.com/ka
 
 ## Start here
 
-- [Home](https://agent-top.pages.dev/): what agent-top is and the one-line install.
-- [Getting started](https://agent-top.pages.dev/getting-started/): install, first run, every key.
-- [Why agent-top exists](https://agent-top.pages.dev/why-this-exists/): the problem it solves and where it is going.
+- [Home](https://agenttop.dev/): what agent-top is and the one-line install.
+- [Getting started](https://agenttop.dev/getting-started/): install, first run, every key.
+- [Why agent-top exists](https://agenttop.dev/why-this-exists/): the problem it solves and where it is going.
 
 ## Guide
 
-- [The live view](https://agent-top.pages.dev/live-view/): the header, the agents table, the process tree, the tool trace, MCP servers, context by source, advice.
-- [Cost report](https://agent-top.pages.dev/report/): `agent-top report`, cross-harness cost and tokens by harness, model, project or day.
-- [Tool trace and export](https://agent-top.pages.dev/trace/): `agent-top trace`, Chrome trace and OTLP/JSON export.
-- [Snapshots and replay](https://agent-top.pages.dev/replay/): `--json` and `--replay`, for bug reports and demos.
-- [Prices](https://agent-top.pages.dev/prices/): the built-in price table and overriding it.
-- [Accounting](https://agent-top.pages.dev/accounting/): where every number comes from.
-- [Harness support](https://agent-top.pages.dev/harnesses/): what is read from each of Claude Code, Codex, Gemini CLI and OpenCode.
+- [The live view](https://agenttop.dev/live-view/): the header, the agents table, the process tree, the tool trace, MCP servers, context by source, advice.
+- [Cost report](https://agenttop.dev/report/): `agent-top report`, cross-harness cost and tokens by harness, model, project or day.
+- [Tool trace and export](https://agenttop.dev/trace/): `agent-top trace`, Chrome trace and OTLP/JSON export.
+- [Snapshots and replay](https://agenttop.dev/replay/): `--json` and `--replay`, for bug reports and demos.
+- [Prices](https://agenttop.dev/prices/): the built-in price table and overriding it.
+- [Accounting](https://agenttop.dev/accounting/): where every number comes from.
+- [Harness support](https://agenttop.dev/harnesses/): what is read from each of Claude Code, Codex, Gemini CLI and OpenCode.
 
 ## Project
 
-- [Vision](https://agent-top.pages.dev/vision/): what agent-top is and is not.
-- [Architecture](https://agent-top.pages.dev/architecture/): the two-crate workspace and what happens on every tick.
-- [Changelog](https://agent-top.pages.dev/changelog/): every release.
-- [Credits](https://agent-top.pages.dev/credits/): what it is built on.
+- [Vision](https://agenttop.dev/vision/): what agent-top is and is not.
+- [Architecture](https://agenttop.dev/architecture/): the two-crate workspace and what happens on every tick.
+- [Changelog](https://agenttop.dev/changelog/): every release.
+- [Credits](https://agenttop.dev/credits/): what it is built on.
 
 ## Blog
 
-- [Five things agent-top shows that your agents will not](https://agent-top.pages.dev/blog/five-things-your-agents-will-not-tell-you/)
-- [The MCP server that outlives its agent](https://agent-top.pages.dev/blog/the-server-that-outlives-its-agent/)
+- [Five things agent-top shows that your agents will not](https://agenttop.dev/blog/five-things-your-agents-will-not-tell-you/)
+- [The MCP server that outlives its agent](https://agenttop.dev/blog/the-server-that-outlives-its-agent/)
 
 ## Optional
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://agent-top.pages.dev/sitemap.xml
+Sitemap: https://agenttop.dev/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 
 site_name: agent-top
 site_description: htop for local coding agents. Processes, subagents, MCP servers, tokens and cost in one terminal view.
-site_url: https://agent-top.pages.dev
+site_url: https://agenttop.dev
 repo_url: https://github.com/kannandreams/agent-top
 repo_name: kannandreams/agent-top
 edit_uri: edit/main/docs/


### PR DESCRIPTION
The Pages project now has agenttop.dev attached as a custom domain. This moves site_url, the README's docs links, robots.txt and llms.txt over to it, so canonical links, Open Graph tags, the JSON-LD block and the sitemap all point at the real domain.