### PR TITLE
docs: revert justified paragraphs to left-aligned

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -301,18 +301,15 @@
   max-width: 38em;
   margin: 0 0 1.4em;
 }
-/* Justified body text: on a monospace face, inter-word justification snaps
- * to the character grid, so the right edge lines up flush against code
- * blocks and screenshots without the uneven word-gaps justify usually
- * brings to a proportional face. The last line of a paragraph is left as
- * the browser leaves it, ragged, which is the readable default. */
-.md-typeset p {
-  text-align: justify;
-  text-justify: inter-word;
-}
+/* Left-aligned, ragged right: justify was tried and reverted. On a
+ * monospace face the browser can only stretch a line's word-gaps in whole
+ * jumps rather than smoothly, so getting the right edge flush means one or
+ * two gaps end up visibly wider than the rest of the line, which reads as
+ * a break rather than an even paragraph. text-wrap: pretty just keeps the
+ * last line of a paragraph from ending on a single short word alone. */
+.md-typeset p,
 .at-lead {
-  text-align: justify;
-  text-justify: inter-word;
+  text-wrap: pretty;
 }
 
 /* Credits: cards in the spirit of charm.land. A quiet border at rest, a blue


### PR DESCRIPTION
Justify (#17) looked fine at a glance but is genuinely uneven on a monospace face: the browser stretches only one or two word-gaps per line to reach the margin, which reads as a break rather than a clean paragraph. Reverted to left-aligned with text-wrap: pretty for orphan control.