### PR TITLE
docs: home page lead spans the full content width

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -298,7 +298,6 @@
   font-size: 0.86rem;
   line-height: 1.6;
   color: var(--at-ink);
-  max-width: 38em;
   margin: 0 0 1.4em;
 }
 /* Left-aligned, ragged right: justify was tried and reverted. On a


### PR DESCRIPTION
Removes the 38em max-width on the home page lead paragraph, which left a blank band to its right while the code block and screenshot beneath it ran the full column.