### PR TITLE
docs: hyperlink README key features and accounting to agenttop.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Coding agents have become long-running processes, and you tend to keep several a
 
 ## Key features
 
-- **Every harness in one view.** Claude Code, Codex, Gemini CLI and OpenCode sessions in a single table, live or recently stopped, so you never tab between four tools to see what is running.
-- **Real tokens and cost.** Counted from the harness's own transcript, never estimated, and priced from a table you can read and edit (Anthropic, OpenAI and Google list prices). Subagents are folded into their parent.
+- **[Every harness in one view](https://agenttop.dev/live-view/).** Claude Code, Codex, Gemini CLI and OpenCode sessions in a single table, live or recently stopped, so you never tab between four tools to see what is running.
+- **[Real tokens and cost](https://agenttop.dev/accounting/).** Counted from the harness's own transcript, never estimated, and priced from a table you can read and edit (Anthropic, OpenAI and Google list prices). Subagents are folded into their parent.
 - **[`agent-top report`](#what-it-all-costs-agent-top-report).** What all of it has cost, across every harness, from the transcripts on disk, grouped by harness, model, project or day. The one place that adds your agent spend up together.
 - **MCP leak detection.** One row per MCP server with its call count, and orphaned servers, a memory leak agent-top watches for on every tick, flagged in red with the agent they were orphaned from.
-- **Context by source.** Which tool's results are filling the prompt, and what re-reading them on every response since has cost: a `Read` that returned 40k tokens is billed again on every turn for the rest of the session, and no harness shows that. Computed from the usage records alone; no tool output is read.
-- **Tool trace, and OpenTelemetry export.** A waterfall of every tool call, inference and turn, reconstructed from the transcript with no telemetry to switch on. Export it as a Chrome trace for Perfetto, or as OTLP JSON, and `trace --endpoint <url>` posts it straight to Jaeger, Tempo or any OpenTelemetry collector.
+- **[Context by source](https://agenttop.dev/accounting/#context-by-source).** Which tool's results are filling the prompt, and what re-reading them on every response since has cost: a `Read` that returned 40k tokens is billed again on every turn for the rest of the session, and no harness shows that. Computed from the usage records alone; no tool output is read.
+- **[Tool trace, and OpenTelemetry export](https://agenttop.dev/trace/).** A waterfall of every tool call, inference and turn, reconstructed from the transcript with no telemetry to switch on. Export it as a Chrome trace for Perfetto, or as OTLP JSON, and `trace --endpoint <url>` posts it straight to Jaeger, Tempo or any OpenTelemetry collector.
 - **Signals the harnesses hide.** How close each agent is to its rate limit (Codex), how much of each prompt is served from cheap cache versus paid at full price, and your live spend velocity in dollars-per-hour across every agent at once.
 - **Read-only and self-contained.** Reads the files the harnesses already write and the process table the OS already keeps. No daemon, no configuration, one static binary; it never writes to or kills an agent, and your data never leaves the machine. The only network calls it makes carry none of your data: a daily update check (turn off with `AGENT_TOP_NO_UPDATE_CHECK=1`) and the `trace --endpoint` you type.
 
@@ -472,8 +472,8 @@ which are exact and which are inferred. In short:
   the one `--endpoint` you type).
 
 The full account, including a worked example of why agent-top and your harness
-can disagree on cost and how to reconcile them, is in
-[docs/accounting.md](docs/accounting.md).
+can disagree on cost and how to reconcile them, is
+[on the docs site](https://agenttop.dev/accounting/).
 
 ## Development
 


### PR DESCRIPTION
## Summary
- "Every harness in one view", "Real tokens and cost", "Context by source" and "Tool trace, and OpenTelemetry export" now hyperlink their titles to the matching agenttop.dev page.
- "Where the numbers come from" now closes with a link to the docs site instead of a repo-relative `docs/accounting.md` path, matching how "Why this exists" already points out to the site.

## Test plan
- `mise run docs:build` (strict) passes.