### PR TITLE
docs: bookmark the Blogs section, green advisory count

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,3 +1,3 @@
-# Blog
+# Blogs
 
 Notes on what agent-top does, why it works the way it does, and what it found on the way.

--- a/docs/hooks/security_scan.py
+++ b/docs/hooks/security_scan.py
@@ -60,6 +60,13 @@ def on_nav(nav, config, files):
     for item in nav.items:
         if item.title == NAV_LABEL:
             item.title = f"Security · {n} advisor{'y' if n == 1 else 'ies'}"
+            # The stylesheet colours this link green, and it cannot read the
+            # count to know whether green is the truth. So the state goes into
+            # the target instead: a clean scan keeps the plain page URL, a
+            # scan with findings points at the panel, which the stylesheet
+            # matches separately and colours as a warning.
+            if n:
+                item.url = "/security/#what-the-scans-say"
     return nav
 
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -455,10 +455,20 @@
   color: var(--md-default-fg-color--light);
 }
 /* The sidebar's scan link carries a number, so it reads as a figure rather
- * than a page name. */
-.md-nav__link[href="/security/"] {
+ * than a page name. Its colour has to follow the count, and CSS cannot read
+ * the count, so docs/hooks/security_scan.py encodes the state in the target:
+ * a clean scan links to the page, a scan with findings links to the panel's
+ * anchor. Green is therefore never shown over a non-zero number. */
+.md-nav__link[href="/security/"],
+.md-nav__link[href^="/security/#"] {
   font-family: var(--at-mono);
   font-size: 0.66rem;
+}
+.md-nav__link[href="/security/"] {
+  color: var(--at-green);
+}
+.md-nav__link[href^="/security/#"] {
+  color: var(--at-warn);
 }
 
 /* Blog index. */
@@ -492,6 +502,22 @@
   font-size: 0.74rem;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--at-line);
+}
+
+/* A bookmark before the Blogs label. Material makes .md-nav__link a flex row
+ * with its own gap and align-items: flex-start, so the spacing is left to that
+ * gap rather than a margin of our own, and the icon is nudged down to sit on
+ * the text's centre instead of the top of the line box. */
+.md-nav--primary .md-nav__item--section .md-nav__link[href$="blog/"]::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.85em;
+  height: 0.85em;
+  margin-top: 0.16em;
+  background-color: currentColor;
+  --at-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.2' stroke-linejoin='round'><path d='M6 3h12a1 1 0 0 1 1 1v17l-7-4.2L5 21V4a1 1 0 0 1 1-1z'/></svg>");
+  -webkit-mask: var(--at-icon) no-repeat center / contain;
+  mask: var(--at-icon) no-repeat center / contain;
 }
 
 /* Site title in the header: the mono face, like the tool's own name. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,7 @@ nav:
       - Architecture: architecture.md
       - Changelog: changelog.md
       - Credits: credits.md
-  - Blog:
+  - Blogs:
       - blog/index.md
   - GitHub: https://github.com/kannandreams/agent-top
   - crates.io: https://crates.io/crates/agent-top


### PR DESCRIPTION
## Summary
- `Blog` → `Blogs`, in the nav and on the blog index page, with a bookmark mark before it in the same masked-SVG style as the GitHub and crates.io marks.
- The sidebar advisory count is now green when it is zero.

The colour is state-aware rather than hardcoded. CSS cannot read the count, so `security_scan.py` encodes the state in the link target: a clean scan keeps `/security/`, a scan with findings points at `/security/#what-the-scans-say`, which the stylesheet matches separately and colours as a warning. Green can never appear over a non-zero number.

## Test plan
- `mise run docs:build` (strict) passes; blog index still lists all 3 posts.
- Both states verified by temporarily setting the count to 3 and rebuilding: label, link target and panel class all switch as expected, then restored.
- Sidebar checked in a headless-Chrome screenshot (icon spacing tuned to Material's own flex `gap`).