### PR TITLE
docs: remove the em dashes, matching the rest of the site

### DIFF
--- a/.agents/skills/agent-top/SKILL.md
+++ b/.agents/skills/agent-top/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-top
-description: Use agent-top to see what coding-agent sessions (Claude Code, Codex, Gemini CLI, OpenCode) are running on this machine, or to debug one after the fact — cost, token burn, why a turn is slow, a tool call that never came back, or an MCP server process left running with no agent above it. Trigger on "why is this agent slow/expensive", "what has this session cost", "check for a leaked/orphaned MCP process", "trace this session", or before assuming a hang is the model thinking rather than a tool call stuck.
+description: Use agent-top to see what coding-agent sessions (Claude Code, Codex, Gemini CLI, OpenCode) are running on this machine, or to debug one after the fact: cost, token burn, why a turn is slow, a tool call that never came back, or an MCP server process left running with no agent above it. Trigger on "why is this agent slow/expensive", "what has this session cost", "check for a leaked/orphaned MCP process", "trace this session", or before assuming a hang is the model thinking rather than a tool call stuck.
 ---
 
 # Using agent-top
@@ -11,8 +11,8 @@ agent-top is a read-only process/transcript viewer for coding-agent sessions. It
 
 ```sh
 agent-top            # live table, one row per session, refreshed every second
-agent-top --once     # the same information, printed once and exit — for a quick look or a script
-agent-top --json      # one snapshot as JSON — pipe it, or attach it to a bug report
+agent-top --once     # the same information, printed once and exit, for a quick look or a script
+agent-top --json      # one snapshot as JSON, to pipe or attach to a bug report
 ```
 
 STATE and COST are the two columns to read first: `running` is mid-turn, `idle` is waiting on you, `stopped` is a transcript with no live process. Cost is priced from the harness's own usage records, not estimated. Select a row to see its detail pane: process tree, MCP servers, and context-by-source (which tool's results are filling the prompt and what re-reading them has cost since).
@@ -35,13 +35,13 @@ agent-top trace --session <id-or-prefix> -o trace.json            # Chrome trace
 agent-top trace --session <id-or-prefix> --format otlp -o t.json  # OTLP/JSON, for Jaeger/Tempo/a collector
 ```
 
-The header line above the waterfall gives the split between tool time and inference time (overlapping calls merged, not summed). A single wide bar on the tools track is one slow call; a row of narrow bars back to back is the model calling a cheap tool repeatedly instead of batching. A bar that starts and never closes is a tool call that never got a result back — check that before trusting whatever the agent did next. Subagent calls sit on their own track, so a fan-out that should have run in parallel but didn't is visible as bars with gaps instead of bars stacked on top of each other.
+The header line above the waterfall gives the split between tool time and inference time (overlapping calls merged, not summed). A single wide bar on the tools track is one slow call; a row of narrow bars back to back is the model calling a cheap tool repeatedly instead of batching. A bar that starts and never closes is a tool call that never got a result back. Check that before trusting whatever the agent did next. Subagent calls sit on their own track, so a fan-out that should have run in parallel but didn't is visible as bars with gaps instead of bars stacked on top of each other.
 
 `--session` takes a session id, a unique prefix of one, or a path to the transcript file directly; it works on a session that already ended, since the trace is reconstructed from the transcript rather than from live telemetry.
 
 ## Is a process leaking
 
-The detail pane lists orphaned MCP servers in red: a process with no live agent above it, its pid, memory, and (when known) which agent it was orphaned from and how long ago. agent-top only reports the pid — killing it is a manual `kill`, on purpose.
+The detail pane lists orphaned MCP servers in red: a process with no live agent above it, its pid, memory, and (when known) which agent it was orphaned from and how long ago. agent-top only reports the pid. Killing it is a manual `kill`, on purpose.
 
 ## Everything above works on someone else's machine too
 
@@ -50,4 +50,4 @@ agent-top --json > snap.json
 agent-top --replay snap.json   # the same screen, reconstructed, no local data read
 ```
 
-Ask for the `--json` snapshot instead of a description when a report doesn't make sense — it reproduces exactly.
+Ask for the `--json` snapshot instead of a description when a report doesn't make sense. It reproduces exactly.

--- a/.claude/skills/agent-top/SKILL.md
+++ b/.claude/skills/agent-top/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-top
-description: Use agent-top to see what coding-agent sessions (Claude Code, Codex, Gemini CLI, OpenCode) are running on this machine, or to debug one after the fact — cost, token burn, why a turn is slow, a tool call that never came back, or an MCP server process left running with no agent above it. Trigger on "why is this agent slow/expensive", "what has this session cost", "check for a leaked/orphaned MCP process", "trace this session", or before assuming a hang is the model thinking rather than a tool call stuck.
+description: Use agent-top to see what coding-agent sessions (Claude Code, Codex, Gemini CLI, OpenCode) are running on this machine, or to debug one after the fact: cost, token burn, why a turn is slow, a tool call that never came back, or an MCP server process left running with no agent above it. Trigger on "why is this agent slow/expensive", "what has this session cost", "check for a leaked/orphaned MCP process", "trace this session", or before assuming a hang is the model thinking rather than a tool call stuck.
 ---
 
 # Using agent-top
@@ -11,8 +11,8 @@ agent-top is a read-only process/transcript viewer for coding-agent sessions. It
 
 ```sh
 agent-top            # live table, one row per session, refreshed every second
-agent-top --once     # the same information, printed once and exit — for a quick look or a script
-agent-top --json      # one snapshot as JSON — pipe it, or attach it to a bug report
+agent-top --once     # the same information, printed once and exit, for a quick look or a script
+agent-top --json      # one snapshot as JSON, to pipe or attach to a bug report
 ```
 
 STATE and COST are the two columns to read first: `running` is mid-turn, `idle` is waiting on you, `stopped` is a transcript with no live process. Cost is priced from the harness's own usage records, not estimated. Select a row to see its detail pane: process tree, MCP servers, and context-by-source (which tool's results are filling the prompt and what re-reading them has cost since).
@@ -35,13 +35,13 @@ agent-top trace --session <id-or-prefix> -o trace.json            # Chrome trace
 agent-top trace --session <id-or-prefix> --format otlp -o t.json  # OTLP/JSON, for Jaeger/Tempo/a collector
 ```
 
-The header line above the waterfall gives the split between tool time and inference time (overlapping calls merged, not summed). A single wide bar on the tools track is one slow call; a row of narrow bars back to back is the model calling a cheap tool repeatedly instead of batching. A bar that starts and never closes is a tool call that never got a result back — check that before trusting whatever the agent did next. Subagent calls sit on their own track, so a fan-out that should have run in parallel but didn't is visible as bars with gaps instead of bars stacked on top of each other.
+The header line above the waterfall gives the split between tool time and inference time (overlapping calls merged, not summed). A single wide bar on the tools track is one slow call; a row of narrow bars back to back is the model calling a cheap tool repeatedly instead of batching. A bar that starts and never closes is a tool call that never got a result back. Check that before trusting whatever the agent did next. Subagent calls sit on their own track, so a fan-out that should have run in parallel but didn't is visible as bars with gaps instead of bars stacked on top of each other.
 
 `--session` takes a session id, a unique prefix of one, or a path to the transcript file directly; it works on a session that already ended, since the trace is reconstructed from the transcript rather than from live telemetry.
 
 ## Is a process leaking
 
-The detail pane lists orphaned MCP servers in red: a process with no live agent above it, its pid, memory, and (when known) which agent it was orphaned from and how long ago. agent-top only reports the pid — killing it is a manual `kill`, on purpose.
+The detail pane lists orphaned MCP servers in red: a process with no live agent above it, its pid, memory, and (when known) which agent it was orphaned from and how long ago. agent-top only reports the pid. Killing it is a manual `kill`, on purpose.
 
 ## Everything above works on someone else's machine too
 
@@ -50,4 +50,4 @@ agent-top --json > snap.json
 agent-top --replay snap.json   # the same screen, reconstructed, no local data read
 ```
 
-Ask for the `--json` snapshot instead of a description when a report doesn't make sense — it reproduces exactly.
+Ask for the `--json` snapshot instead of a description when a report doesn't make sense. It reproduces exactly.

--- a/docs/blog/posts/what-tracing-means-for-an-agent-session.md
+++ b/docs/blog/posts/what-tracing-means-for-an-agent-session.md
@@ -8,7 +8,7 @@ description: "What a trace and a span mean once the workload is an agent loop in
 
 # What tracing means for an agent session
 
-Tracing is an old idea from distributed systems: a request comes in, it fans out into work on several services, and if you want to know where the time went you need to see all of that work on one shared timeline, with the causal links between the pieces intact. A **span** is one piece of work with a start, an end, and a name. A **trace** is a tree of spans that all belong to the same request. The reason the idea generalized past HTTP services is that it doesn't actually care what the work is — only that it has a beginning, an end, and a parent.
+Tracing is an old idea from distributed systems: a request comes in, it fans out into work on several services, and if you want to know where the time went you need to see all of that work on one shared timeline, with the causal links between the pieces intact. A **span** is one piece of work with a start, an end, and a name. A **trace** is a tree of spans that all belong to the same request. The reason the idea generalized past HTTP services is that it doesn't actually care what the work is, only that it has a beginning, an end, and a parent.
 
 An agent turn has exactly that shape. You send a prompt. The model thinks, then calls a tool, then thinks again about the result, maybe calls three tools in parallel, spins up a subagent that does the same thing one level down, and eventually replies. That's a trace. The model's thinking is a span. Each tool call is a span. The subagent's whole turn is a span containing its own spans. Nothing about applying tracing to this is a stretch; the only question is where the spans come from.
 
@@ -18,9 +18,9 @@ An agent turn has exactly that shape. You send a prompt. The model thinks, then 
 
 The usual way to get a trace is instrumentation: you put OpenTelemetry calls around the code, ship spans to a collector, and only requests that happened after you did that are visible. Agent harnesses don't need that step, because the transcript they write for their own purposes already contains the trace, just not shaped like one.
 
-Take Claude Code's JSONL. A tool call is a `tool_use` block; the answer is a `tool_result` a few lines later carrying the same `tool_use_id`. Codex pairs `function_call` and `function_call_output` by `call_id`. Both harnesses stamp the surrounding lines with a timestamp. That's a span: an id to pair begin and end, a start time, an end time once the pair completes. The file was never trying to be a trace — it's an append-only record of a conversation — but a trace is just what you get once you fold matching begin/end pairs into intervals.
+Take Claude Code's JSONL. A tool call is a `tool_use` block; the answer is a `tool_result` a few lines later carrying the same `tool_use_id`. Codex pairs `function_call` and `function_call_output` by `call_id`. Both harnesses stamp the surrounding lines with a timestamp. That's a span: an id to pair begin and end, a start time, an end time once the pair completes. The file was never trying to be a trace. It is an append-only record of a conversation. But a trace is just what you get once you fold matching begin/end pairs into intervals.
 
-One consequence follows: the trace is retroactive. You don't decide to trace a session before it starts. You point at a transcript, today, for a session that ended last Tuesday, and get the same trace you'd have gotten if OpenTelemetry had been wired in from the first line. Nothing has to be switched on in the harness, which also means it works the same for every harness that writes a transcript with paired call/result records and a timestamp — Claude Code, Codex, Gemini CLI, OpenCode — without four different SDKs to integrate.
+One consequence follows: the trace is retroactive. You don't decide to trace a session before it starts. You point at a transcript, today, for a session that ended last Tuesday, and get the same trace you'd have gotten if OpenTelemetry had been wired in from the first line. Nothing has to be switched on in the harness, which also means it works the same for every harness that writes a transcript with paired call/result records and a timestamp, whether that is Claude Code, Codex, Gemini CLI or OpenCode, without four different SDKs to integrate.
 
 ## Building the tree
 
@@ -32,7 +32,7 @@ agent-top's reconstruction (`crates/agent-top/src/trace.rs`) keeps it to three s
 | inference | one model response: from the request to its last token |
 | tool | one tool call, from the request to its result |
 
-Parenting a tool or inference span to its turn isn't stored anywhere in the transcript; there's no `turn_id` on a tool call. It's recovered by interval containment — a turn opens at your prompt and closes at the reply, so anything that started while that window was open and hadn't already been claimed by a narrower open turn belongs to it:
+Parenting a tool or inference span to its turn isn't stored anywhere in the transcript; there's no `turn_id` on a tool call. It's recovered by interval containment. A turn opens at your prompt and closes at the reply, so anything that started while that window was open and hadn't already been claimed by a narrower open turn belongs to it:
 
 ```rust
 fn parent_turn<'a>(spans: &[&'a ToolSpan], i: usize) -> Option<&'a ToolSpan> {
@@ -51,9 +51,9 @@ fn parent_turn<'a>(spans: &[&'a ToolSpan], i: usize) -> Option<&'a ToolSpan> {
 }
 ```
 
-Subagent spans prefer a subagent turn of their own if the transcript carries one, and fall back to the main turn otherwise — which is the whole rule for keeping a subagent's fan-out on its own branch of the tree instead of flattening it into the parent's.
+Subagent spans prefer a subagent turn of their own if the transcript carries one, and fall back to the main turn otherwise. That is the whole rule for keeping a subagent's fan-out on its own branch of the tree instead of flattening it into the parent's.
 
-The other case is a span that never closes. A tool call issued right as the transcript ends, or a session that's still running when you export it, has no end timestamp. Inventing one — "assume it took as long as the last call" — would make a trace that lies. So an open span keeps its start and gets no end: in Chrome trace format that's a begin event (`"ph": "B"`) with no matching end, which Perfetto draws as a slice with no closing edge instead of a slice with a fabricated width; in OTLP, where an end time is mandatory, it gets one equal to its start plus an `agent_top.open` attribute, so a reader can tell "zero duration" from "we don't know."
+The other case is a span that never closes. A tool call issued right as the transcript ends, or a session that's still running when you export it, has no end timestamp. Inventing one, by assuming it took as long as the last call, would make a trace that lies. So an open span keeps its start and gets no end: in Chrome trace format that's a begin event (`"ph": "B"`) with no matching end, which Perfetto draws as a slice with no closing edge instead of a slice with a fabricated width; in OTLP, where an end time is mandatory, it gets one equal to its start plus an `agent_top.open` attribute, so a reader can tell "zero duration" from "we don't know."
 
 ## Two shapes, two audiences
 
@@ -64,9 +64,9 @@ agent-top trace --session 9f2c1a4e -o trace.json            # Chrome trace forma
 agent-top trace --session 9f2c1a4e --format otlp -o t.json  # OTLP/JSON
 ```
 
-Chrome trace format needs no server — `ui.perfetto.dev` or `chrome://tracing` opens the file directly, which makes it the right first look for one session. OTLP is the interchange format if you already run Jaeger, Tempo, or a collector, and want the agent's turn to show up next to the rest of your system's traces rather than in a separate tool. `--endpoint` posts it there directly, and it's the only network call in agent-top that carries session data anywhere — no default endpoint, no config file, it only happens when you type the URL on the command line.
+Chrome trace format needs no server. `ui.perfetto.dev` or `chrome://tracing` opens the file directly, which makes it the right first look for one session. OTLP is the interchange format if you already run Jaeger, Tempo, or a collector, and want the agent's turn to show up next to the rest of your system's traces rather than in a separate tool. `--endpoint` posts it there directly, and it's the only network call in agent-top that carries session data anywhere. There is no default endpoint and no config file, it only happens when you type the URL on the command line.
 
-One detail that matters if you ever diff two exports: span and trace ids are derived from the session id and each span's own id (FNV-1a, not random), so exporting the same session twice produces byte-identical ids. Export a session before and after changing a system prompt and the tool spans that didn't change keep the same id across both files — useful if you're trying to isolate which turn got slower rather than eyeballing two unrelated-looking traces.
+One detail that matters if you ever diff two exports: span and trace ids are derived from the session id and each span's own id (FNV-1a, not random), so exporting the same session twice produces byte-identical ids. Export a session before and after changing a system prompt and the tool spans that didn't change keep the same id across both files, which is useful if you're trying to isolate which turn got slower rather than eyeballing two unrelated-looking traces.
 
 ## Reading the waterfall without leaving the terminal
 
@@ -74,7 +74,7 @@ You don't need Perfetto to get the first read. `Tab` in the detail pane switches
 
 ![The tool trace: every tool call and model response on one time axis](../../screenshots/tool-trace.png)
 
-The header line above the waterfall is the one number that answers the question people actually ask, which is "why has this agent been busy for eight minutes": the share of the window that was tool time versus inference time, with overlapping tool calls merged rather than summed so five parallel calls that each took four seconds don't get counted as twenty seconds of tool time. If that share is mostly tool, one call is the long pole and it's usually the widest bar on the tools track. If it's mostly the gap, the model was thinking — and no span log fixes a slow model, but at least you've ruled out the tool.
+The header line above the waterfall is the one number that answers the question people actually ask, which is "why has this agent been busy for eight minutes": the share of the window that was tool time versus inference time, with overlapping tool calls merged rather than summed so five parallel calls that each took four seconds don't get counted as twenty seconds of tool time. If that share is mostly tool, one call is the long pole and it's usually the widest bar on the tools track. If it's mostly the gap, the model was thinking. No span log fixes a slow model, but at least you've ruled out the tool.
 
 ## Debugging a slow turn
 
@@ -86,11 +86,11 @@ agent-top trace --session 9f2c1a4e -o slow-turn.json
 
 Open it in Perfetto. Three things to check, roughly in order of how often each one turns out to be the answer:
 
-**Is it one call or many?** A single wide bar on the tools track is a tool that's slow, full stop — an MCP server making a network round trip, a shell command that's actually doing nine minutes of work. A row of narrow bars back to back is a chattier pattern: the model calling a cheap tool repeatedly instead of batching, which is a prompting problem, not an infrastructure one. The waterfall makes the two look different at a glance in a way a duration number in a log line doesn't.
+**Is it one call or many?** A single wide bar on the tools track is a tool that's slow, full stop: an MCP server making a network round trip, a shell command that's actually doing nine minutes of work. A row of narrow bars back to back is a chattier pattern: the model calling a cheap tool repeatedly instead of batching, which is a prompting problem, not an infrastructure one. The waterfall makes the two look different at a glance in a way a duration number in a log line doesn't.
 
-**Did anything not come back?** A begin event with no end — a slice that starts and never closes — is the same signature you'd get from [an MCP server that stopped answering](the-server-that-outlives-its-agent.md). If the transcript ended mid-call, that's expected. If it's mid-session and the agent moved on to something else anyway, the harness gave up waiting on that call, and the tool result the model based its next step on either arrived late or never arrived — worth knowing before you trust the turn after it.
+**Did anything not come back?** A begin event with no end, a slice that starts and never closes, is the same signature you'd get from [an MCP server that stopped answering](the-server-that-outlives-its-agent.md). If the transcript ended mid-call, that's expected. If it's mid-session and the agent moved on to something else anyway, the harness gave up waiting on that call, and the tool result the model based its next step on either arrived late or never arrived, which is worth knowing before you trust the turn after it.
 
-**Did the subagent track run serially when it should have run in parallel?** Subagent spans sit on their own tracks specifically so a fan-out that should overlap and doesn't is visible as five bars stacked with gaps between them instead of five bars stacked on top of each other. That shape — sequential when the intent was parallel — is easy to miss in a transcript and impossible to miss in a waterfall.
+**Did the subagent track run serially when it should have run in parallel?** Subagent spans sit on their own tracks specifically so a fan-out that should overlap and doesn't is visible as five bars stacked with gaps between them instead of five bars stacked on top of each other. That shape, sequential when the intent was parallel, is easy to miss in a transcript and impossible to miss in a waterfall.
 
 None of this requires you to have decided, ahead of time, that this session might need tracing. The input is the same file the harness wrote to remember what happened, so the trace is available after the fact, for every session you have already run.
 

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -93,7 +93,7 @@ agent-top is one static binary, and most of what makes it work was written by ot
 <span class="at-star" aria-hidden="true">★</span>
 <span class="at-mark">tf</span>
 <span class="at-name">Tuff <span class="at-tag">By the agent-top creator</span></span>
-<p>Installs and tracks the skills and MCP servers this repository hands its coding agents — including the agent-top skill below.</p>
+<p>Installs and tracks the skills and MCP servers this repository hands its coding agents, including the agent-top skill below.</p>
 <span class="at-link">tuffcli.dev</span>
 </a>
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,7 +22,7 @@ Three checks run in [the Security workflow](https://github.com/kannandreams/agen
 
 The daily run catches what a push cannot: an advisory published against an unchanged `Cargo.lock` is a new vulnerability in a release that has already shipped.
 
-The supply-chain rules are in [`deny.toml`](https://github.com/kannandreams/agent-top/blob/main/deny.toml). Every crate must come from crates.io — no git dependencies, no alternative registries — and carry a licence from an explicit permissive allowlist. A wildcard version requirement fails the build.
+The supply-chain rules are in [`deny.toml`](https://github.com/kannandreams/agent-top/blob/main/deny.toml). Every crate must come from crates.io, with no git dependencies and no alternative registries, and carry a licence from an explicit permissive allowlist. A wildcard version requirement fails the build.
 
 To run the same checks yourself:
 
@@ -34,12 +34,12 @@ mise run security             # both, the way CI does
 
 ## What it reads
 
-The process table (through `sysinfo` and, on macOS, `libproc` — not by shelling out to `ps`) and the transcript files each harness already writes. From a transcript it takes metadata: usage records (token counts), tool and MCP call names, ids, timestamps, session id, model, working directory. It does not read prompt text or tool output. [Context by source](accounting.md#context-by-source) works within that boundary: what a tool result added to the prompt is priced from the token counts alone, not from the result. [Accounting](accounting.md) has the arithmetic.
+The process table (through `sysinfo` and, on macOS, `libproc`, not by shelling out to `ps`) and the transcript files each harness already writes. From a transcript it takes metadata: usage records (token counts), tool and MCP call names, ids, timestamps, session id, model, working directory. It does not read prompt text or tool output. [Context by source](accounting.md#context-by-source) works within that boundary: what a tool result added to the prompt is priced from the token counts alone, not from the result. [Accounting](accounting.md) has the arithmetic.
 
 ## What it never does
 
 - **Never writes to a transcript.** The files a harness owns are never touched.
-- **Never signals or kills a process.** An orphaned MCP server is reported — pid, memory, age, the agent it came from — and the `kill` is yours. See [what agent-top is not](vision.md#what-agent-top-is-not).
+- **Never signals or kills a process.** An orphaned MCP server is reported with its pid, memory, age and the agent it came from, and the `kill` is yours. See [what agent-top is not](vision.md#what-agent-top-is-not).
 - **No shell-outs for discovery.** Process and file information comes from library calls (`sysinfo`, `libproc`), not from parsing the output of `ps`, `lsof`, or any other command.
 - **No credentials, no provider.** agent-top does not hold an API key or talk to a model.
 - **No `unsafe`.** There is no `unsafe` block in either crate.
@@ -48,18 +48,18 @@ The process table (through `sysinfo` and, on macOS, `libproc` — not by shellin
 
 There are two.
 
-1. **A daily version check.** `GET https://crates.io/api/v1/crates/agent-top` with a fixed `User-Agent` and nothing else — no session data, no machine identifier, no query string. Cached to run at most once a day, in `~/.cache/agent-top/update-check.json` (or `$XDG_CACHE_HOME/agent-top/update-check.json`), which holds when it last checked, what it found, and which version you dismissed. `AGENT_TOP_NO_UPDATE_CHECK=1` turns it off.
+1. **A daily version check.** `GET https://crates.io/api/v1/crates/agent-top` with a fixed `User-Agent` and nothing else: no session data, no machine identifier, no query string. Cached to run at most once a day, in `~/.cache/agent-top/update-check.json` (or `$XDG_CACHE_HOME/agent-top/update-check.json`), which holds when it last checked, what it found, and which version you dismissed. `AGENT_TOP_NO_UPDATE_CHECK=1` turns it off.
 2. **`trace --endpoint <url>`.** Posts the OTLP document to the address typed on the command line, once. No default endpoint, no config key, no environment variable that turns it on.
 
 Nothing else opens a connection. `--json` and `--replay` never touch the network; replay reads only the file you give it.
 
 ## The one command that changes the machine
 
-Accepting the upgrade prompt (`u`) runs a fixed command line chosen by detecting how the running binary was installed — `brew update && brew upgrade agent-top`, `cargo binstall -y agent-top`, or `cargo install --locked agent-top` — never a string built from input, and never through a shell. The command is printed before it runs, and it runs only on that keypress.
+Accepting the upgrade prompt (`u`) runs a fixed command line chosen by detecting how the running binary was installed: `brew update && brew upgrade agent-top`, `cargo binstall -y agent-top`, or `cargo install --locked agent-top`. It is never a string built from input, and it never runs through a shell. The command is printed before it runs, and it runs only on that keypress.
 
 ## Local files it touches
 
-**Reads:** the transcripts, the process table, and — if it exists — `~/.config/agent-top/prices.toml`. A malformed price file is reported on stderr and ignored; the built-in prices still apply. See [Prices](prices.md).
+**Reads:** the transcripts, the process table, and `~/.config/agent-top/prices.toml` if it exists. A malformed price file is reported on stderr and ignored; the built-in prices still apply. See [Prices](prices.md).
 
 **Writes:** the one cache file above. `--replay` and `--json` read and print; neither touches disk beyond the file you point at.
 

--- a/docs/why-this-exists.md
+++ b/docs/why-this-exists.md
@@ -12,4 +12,4 @@ I wanted one screen for that. The metadata already exists. Every harness writes 
 
 That is the direction: observability for the agents on your machine. Metrics, cost and the cross-harness report are there today. Advice on bad deals, failed-tool and slowest-tool views, and rate-limit warnings came next. Alerts, error tracking and a fuller FinOps history are where it goes from here. Throughout, it stays read-only, sends nothing anywhere, and ships as one binary.
 
-For the fuller picture — what the tool is, and what it deliberately is not — see [Vision](vision.md).
+For the fuller picture of what the tool is, and what it deliberately is not, see [Vision](vision.md).

--- a/tuff.lock
+++ b/tuff.lock
@@ -24,7 +24,7 @@
       "description": "What this skill helps the agent do.",
       "target": "claude",
       "installed_path": ".claude/skills/agent-top",
-      "sha256": "4d7954534cc0542fe2cd0aa52522d2c8d80ca3e8ca0954b58fcfa8f405bac03e",
+      "sha256": "af30a32558fdc3c024417106a509eb5f3027fa72cca1b69fafcc188877e39039",
       "ownership": "generated",
       "source": {
         "kind": "local",
@@ -39,7 +39,7 @@
       "description": "What this skill helps the agent do.",
       "target": "open-agents",
       "installed_path": ".agents/skills/agent-top",
-      "sha256": "4d7954534cc0542fe2cd0aa52522d2c8d80ca3e8ca0954b58fcfa8f405bac03e",
+      "sha256": "af30a32558fdc3c024417106a509eb5f3027fa72cca1b69fafcc188877e39039",
       "ownership": "generated",
       "source": {
         "kind": "local",


### PR DESCRIPTION
## Summary

Em dash counts before this change:

| File | Em dashes | Words |
|---|---|---|
| accounting, live-view, trace, report, vision | 0 | ~3,700 |
| both earlier blog posts | 0 | ~2,560 |
| **security.md** | **10** | 740 |
| **the tracing post** | **19** | 1,647 |
| **agent-top SKILL.md** | **6** | 500 |
| why-this-exists, credits | 1 each | |

The convention on this site is clearly no em dashes, and every one present had been introduced this week. Rewritten as full stops, commas and colons rather than swapped for a different dash, so sentences got shorter rather than merely repunctuated.

The one em dash left in README.md predates this and is untouched.

## Test plan
- `mise run docs:build` (strict) passes.
- `tuff check` clean after re-syncing the skill baselines for both targets.