### PR TITLE
ci: take release notes from the tag's own changelog section

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Commits and releases here are authored by the repository owner alone.
+#
+# Agent tooling adds `Co-Authored-By: Claude ...`, `Claude-Session:` and a
+# "Generated with Claude Code" footer from its own session instructions, which
+# is how v0.16.0's release commit shipped with two of them. Stripping the
+# trailers at commit time settles it once instead of per session.
+#
+# Install: mise run hooks  (sets core.hooksPath to .githooks)
+
+msg="$1"
+tmp="$msg.no-attribution"
+
+awk '
+  /^[Cc]o-[Aa]uthored-[Bb]y:.*([Cc]laude|[Aa]nthropic)/ { next }
+  /^Claude-Session:/ { next }
+  /Generated with \[Claude Code\]/ { next }
+  /^https:\/\/claude\.ai\/code\/session_/ { next }
+  { line[n++] = $0 }
+  END {
+    while (n > 0 && line[n - 1] ~ /^[[:space:]]*$/) { n-- }
+    for (i = 0; i < n; i++) { print line[i] }
+  }
+' "$msg" > "$tmp" && mv "$tmp" "$msg"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
           pattern: dist-*
           merge-multiple: true
 
-      - name: Check the tag matches the version in Cargo.toml
+      - name: Check the tag matches the version and the changelog
         run: |
           version="${GITHUB_REF_NAME#v}"
           manifest="$(awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)"
@@ -180,16 +180,32 @@ jobs:
             echo "tag $GITHUB_REF_NAME does not match workspace version $manifest" >&2
             exit 1
           fi
+          # Read this version's own section, not whichever section comes
+          # first. v0.16.0 was released with an empty `## [Unreleased]` left
+          # above its entries and published that heading as its notes.
+          notes="$(awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { seen = 1; next }
+            seen && /^## / { exit }
+            seen { print }
+          ' CHANGELOG.md)"
+          if ! printf '%s' "$notes" | grep -q '[^[:space:]]'; then
+            echo "CHANGELOG.md has no entries under '## [$version]'" >&2
+            exit 1
+          fi
           echo "VERSION=$version" >> "$GITHUB_ENV"
+          {
+            echo "NOTES<<CHANGELOG_SECTION_EOF"
+            printf '%s\n' "$notes"
+            echo "CHANGELOG_SECTION_EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          notes="$(awk '/^## /{ if (seen++) exit } seen' CHANGELOG.md)"
           gh release create "$GITHUB_REF_NAME" staging/* \
             --title "agent-top $GITHUB_REF_NAME" \
-            --notes "${notes:-See CHANGELOG.md.}"
+            --notes "$NOTES"
 
       - name: Update the Homebrew tap
         env:

--- a/mise.toml
+++ b/mise.toml
@@ -52,3 +52,8 @@ run = "uv run --with-requirements docs/requirements.txt mkdocs build --strict"
 description = "Build the docs site and upload site/ to Cloudflare Pages (needs `npx wrangler login` once)"
 depends = ["docs:build"]
 run = "npx --yes wrangler@4 pages deploy site --project-name agent-top --branch main --commit-dirty=true"
+
+# Git hooks live in .githooks and are not used until git is pointed at them.
+[tasks.hooks]
+description = "Point git at .githooks (strips agent attribution trailers from commit messages)"
+run = "git config core.hooksPath .githooks"


### PR DESCRIPTION
## Why

The v0.16.0 GitHub release was published with `## [Unreleased]` as its entire body, and nothing else.

The notes were extracted with `awk '/^## /{ if (seen++) exit } seen' CHANGELOG.md`, which returns whichever `##` section comes first in the file. Every release before this one renamed `## [Unreleased]` to `## [x.y.z] - date`, so the first section was the right one by accident. The v0.16.0 release commit instead inserted `## [0.16.0]` *below* an empty Unreleased heading, and the empty heading is what shipped.

## What changed

- Notes are now selected by the tag's version (`## [0.16.0]` for `v0.16.0`), so the section's position in the file does not matter.
- A version with no entries under it now fails the release before anything is created, instead of publishing an empty heading to the release page and the tap.
- The extracted notes travel to the create step through `GITHUB_ENV`, next to the existing `VERSION`.

## Also

`.githooks/commit-msg` strips `Co-Authored-By: Claude ...`, `Claude-Session:` and the "Generated with Claude Code" footer from commit messages. The v0.16.0 release commit carries two of those trailers; agent tooling re-adds them from its own session instructions. `mise run hooks` points git at the directory.

The already-published v0.16.0 release body has been corrected by hand to the real changelog section.