### PR TITLE
ci: trim the blank lines around the extracted release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,13 @@ jobs:
           notes="$(awk -v v="$version" '
             $0 ~ "^## \\[" v "\\]" { seen = 1; next }
             seen && /^## / { exit }
-            seen { print }
+            seen { line[n++] = $0 }
+            END {
+              first = 0
+              while (first < n && line[first] ~ /^[[:space:]]*$/) { first++ }
+              while (n > first && line[n - 1] ~ /^[[:space:]]*$/) { n-- }
+              for (i = first; i < n; i++) { print line[i] }
+            }
           ' CHANGELOG.md)"
           if ! printf '%s' "$notes" | grep -q '[^[:space:]]'; then
             echo "CHANGELOG.md has no entries under '## [$version]'" >&2


### PR DESCRIPTION
The version heading in `CHANGELOG.md` is followed by a blank line, and #31 skips the heading itself, so the extracted notes began with that blank line. The v0.16.0 release body opens with it today. Harmless, but visible on the release page and it would repeat at every tag.

The section is now buffered and its leading and trailing blank lines dropped before the notes reach `gh release create`.

Checked against `## [0.16.0]` and `## [0.15.2]` (both now start at `### Added` / `### Changed`) and against a version with no section, which still fails the release.